### PR TITLE
Wallet transaction test with live wallet data

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -32,3 +32,5 @@ jobs:
 
       - name: Test
         run: wasm-pack test --headless --chrome
+        env:
+          TEST_WALLET_SEED: ${{ secrets.TEST_WALLET_SEED }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use operations::{
     rgb::{accept_transfer, blind_utxo, get_asset, get_assets, transfer_asset, validate_transfer},
 };
 
-pub use utils::{resolve, set_panic_hook, to_string};
+pub use utils::{json_parse, resolve, set_panic_hook, to_string};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::unused_unit)]
 use std::collections::HashMap;
 
-use bdk::{wallet::AddressIndex::New, TransactionDetails};
+use bdk::{wallet::AddressIndex::New, BlockTime};
+use bitcoin::Txid;
 use gloo_console::log;
 use gloo_storage::{LocalStorage, Storage};
 use js_sys::Promise;
@@ -186,7 +187,18 @@ pub fn save_mnemonic_seed(
 pub struct WalletData {
     pub address: String,
     pub balance: String,
-    pub transactions: Vec<TransactionDetails>,
+    pub transactions: Vec<WalletTransaction>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub struct WalletTransaction {
+    pub txid: Txid,
+    pub received: u64,
+    pub sent: u64,
+    pub fee: Option<u64>,
+    pub confirmed: bool,
+    pub confirmation_time: Option<BlockTime>,
+    pub verified: bool,
 }
 
 #[wasm_bindgen]
@@ -221,6 +233,20 @@ pub fn get_wallet_data(descriptor: String, change_descriptor: String) -> Promise
         LocalStorage::set(STORAGE_KEY_TRANSACTIONS, &transactions).unwrap_or_else(|_| {
             log!("failed at saving unspents to local");
         });
+
+        let transactions: Vec<WalletTransaction> = transactions
+            .into_iter()
+            .map(|tx| WalletTransaction {
+                txid: tx.txid,
+                received: tx.received,
+                sent: tx.sent,
+                fee: tx.fee,
+                confirmed: tx.confirmation_time.is_some(),
+                confirmation_time: tx.confirmation_time,
+                verified: tx.verified,
+            })
+            .collect();
+
         let wallet_data = WalletData {
             address,
             balance,

--- a/src/operations/bitcoin/send_sats.rs
+++ b/src/operations/bitcoin/send_sats.rs
@@ -33,7 +33,7 @@ pub async fn create_transaction(
     log!("Unsigned PSBT: {}", base64::encode(&serialize(&psbt)));
     let signing = sign_psbt(wallet, psbt).await;
     match signing {
-        Ok(_signing) => Ok("Ok".to_string()),
+        Ok(_signing) => Ok(serde_json::to_string(&details)?),
         Err(_e) => Ok("Server error".to_string()),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use js_sys::Promise;
+use serde::de::DeserializeOwned;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
@@ -19,4 +20,8 @@ pub async fn resolve(promise: Promise) -> JsValue {
 
 pub fn to_string(js_str: &JsValue) -> String {
     js_str.as_string().unwrap()
+}
+
+pub fn json_parse<T: DeserializeOwned>(js_str: &JsValue) -> T {
+    serde_json::from_str(&js_str.as_string().unwrap()).expect("parsed json")
 }

--- a/tests/asset.rs
+++ b/tests/asset.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
 use bitmask_core::{
-    get_vault, get_wallet_data, import_asset, resolve, save_mnemonic_seed, to_string, VaultData,
+    get_vault, get_wallet_data, import_asset, json_parse, resolve, save_mnemonic_seed, VaultData,
     WalletData,
 };
 
@@ -30,7 +30,7 @@ async fn asset_import() {
 
     // Get vault properties
     let vault_str: JsValue = resolve(get_vault(ENCRYPTION_PASSWORD.to_owned())).await;
-    let vault_data: VaultData = serde_json::from_str(&to_string(&vault_str)).unwrap();
+    let vault_data: VaultData = json_parse(&vault_str);
 
     resolve(import_asset(
         vault_data.descriptor.clone(),
@@ -48,7 +48,7 @@ async fn asset_import() {
     .await;
 
     // Parse wallet data
-    let wallet_data: WalletData = serde_json::from_str(&to_string(&wallet_str)).unwrap();
+    let wallet_data: WalletData = json_parse(&wallet_str);
 
     assert_eq!(wallet_data.transactions, vec![]);
 }


### PR DESCRIPTION
Add a test using a live testnet wallet with actual transactions in it. Use an environment variable to hold the seed. Add a new WalletTransaction struct that copies the one from BDK, but adds an explicit "confirmed" field.

Uses a GitHub actions secret.

Closes #5 

- [x] Ensure the `confirmed` property exists and behaves as expected
- [x] Tests sending transactions
- [x] Tests Activity states like pending
