### PR TITLE
Publishing data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use serde_encrypt::{
 };
 use sha2::{Digest, Sha256};
 
-mod data;
+pub mod data;
 mod operations;
 mod util;
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
I need to access to bitmask_core::data::structs::SealCoins for bitmask_lambda. It's probable that we will need to access to other structs. Provissionally I added a pub to mod data.., but if you think of a better way, @cryptoquick,  we can do it.