### PR TITLE
Add BDK sled wallet database for desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,6 @@ dependencies = [
  "serde",
  "serde-encrypt",
  "serde_json",
- "sha2 0.10.2",
  "sled",
  "stens",
  "storm-core",
@@ -375,15 +374,6 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -745,7 +735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
  "serde",
  "subtle",
@@ -844,16 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
-dependencies = [
- "block-buffer 0.10.2",
- "crypto-common",
-]
-
-[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,7 +872,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -2558,22 +2538,11 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ rgb20 = { version = "0.8.0-rc.3", features = ["serde"] }
 serde = "1.0.130"
 serde_json = "1.0.68"
 serde-encrypt = "0.7.0"
-sha2 = "0.10.1"
 stens = { version = "0.7.1", features = ["serde"] }
 storm-core = "0.8.0"
 strict_encoding = { version = "0.8.1", features = [

--- a/src/operations/bitcoin/balance.rs
+++ b/src/operations/bitcoin/balance.rs
@@ -1,46 +1,32 @@
-use std::rc::Rc;
-
 use anyhow::Result;
-use bdk::{blockchain::esplora::EsploraBlockchain, database::MemoryDatabase, SyncOptions, Wallet};
+use bdk::{blockchain::esplora::EsploraBlockchain, database::AnyDatabase, SyncOptions, Wallet};
+use bitcoin_hashes::{sha256, Hash, HashEngine};
 
-use crate::data::{
-    constants::{BITCOIN_EXPLORER_API, NETWORK},
-    structs::ThinAsset,
+use crate::{
+    data::constants::{BITCOIN_EXPLORER_API, NETWORK},
+    debug,
 };
-
-#[allow(dead_code)] // TODO: Should this code be used?
-#[derive(Default, Clone)]
-struct State {
-    wallet: Rc<Option<Wallet<MemoryDatabase>>>,
-    rgb_assets: Option<Vec<ThinAsset>>,
-    address: String,
-    balance: String,
-}
 
 pub fn get_wallet(
     descriptor: &str,
     change_descriptor: Option<&str>,
-) -> Result<Wallet<MemoryDatabase>> {
-    // #[cfg(not(target_arch = "wasm32"))]
-    // let db = {
-    //     use directories::ProjectDirs;
-    //     use regex::Regex;
+) -> Result<Wallet<AnyDatabase>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let db = {
+        use directories::ProjectDirs;
+        let mut engine = sha256::Hash::engine();
+        engine.input(descriptor.as_bytes());
+        if let Some(change_descriptor) = change_descriptor {
+            engine.input(change_descriptor.as_bytes());
+        };
+        let hash = sha256::Hash::from_engine(engine);
+        debug!("Descriptor hash:", hash.to_string());
+        let project_dirs = ProjectDirs::from("org", "DIBA", "BitMask").unwrap();
+        let db: sled::Db = sled::open(project_dirs.data_local_dir().join("wallet_db"))?;
+        AnyDatabase::Sled(db.open_tree(hash).unwrap())
+    };
 
-    //     let re = Regex::new(r"\(\[([0-9a-f]+)/(.+)](.+)/").unwrap();
-    //     let cap = re.captures(descriptor).unwrap();
-    //     let fingerprint = &cap[1];
-    //     let fingerprint = if let Some(change_descriptor) = change_descriptor {
-    //         let cap = re.captures(change_descriptor).unwrap();
-    //         [fingerprint, &cap[1]].join("_")
-    //     } else {
-    //         fingerprint.to_owned()
-    //     };
-    //     let project_dirs = ProjectDirs::from("org", "DIBA", "BitMask").unwrap();
-    //     let db: sled::Db = sled::open(project_dirs.data_local_dir().join("wallet_db"))?;
-    //     db.open_tree(fingerprint).unwrap()
-    // };
-
-    // #[cfg(target_arch = "wasm32")]
+    #[cfg(target_arch = "wasm32")]
     let db = MemoryDatabase::default();
 
     let wallet = Wallet::new(descriptor, change_descriptor, *NETWORK.read().unwrap(), db)?;
@@ -51,7 +37,7 @@ pub fn get_blockchain() -> EsploraBlockchain {
     EsploraBlockchain::new(&BITCOIN_EXPLORER_API.read().unwrap(), 100)
 }
 
-pub async fn synchronize_wallet(wallet: &Wallet<MemoryDatabase>) -> Result<()> {
+pub async fn synchronize_wallet(wallet: &Wallet<AnyDatabase>) -> Result<()> {
     let blockchain = get_blockchain();
     wallet.sync(&blockchain, SyncOptions::default()).await?;
     Ok(())

--- a/src/operations/bitcoin/send_sats.rs
+++ b/src/operations/bitcoin/send_sats.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bdk::{database::MemoryDatabase, FeeRate, Wallet};
+use bdk::{database::AnyDatabase, FeeRate, Wallet};
 use bitcoin::{consensus::serialize, Transaction};
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
 
 pub async fn create_transaction(
     invoices: Vec<SatsInvoice>,
-    wallet: &Wallet<MemoryDatabase>,
+    wallet: &Wallet<AnyDatabase>,
 ) -> Result<Transaction> {
     synchronize_wallet(wallet).await?;
     let (psbt, details) = {

--- a/src/operations/bitcoin/sign_psbt.rs
+++ b/src/operations/bitcoin/sign_psbt.rs
@@ -1,11 +1,11 @@
 use anyhow::{Error, Result};
-use bdk::{blockchain::Blockchain, database::MemoryDatabase, SignOptions, Wallet};
+use bdk::{blockchain::Blockchain, database::AnyDatabase, SignOptions, Wallet};
 use bitcoin::{consensus::serialize, util::psbt::PartiallySignedTransaction, Transaction};
 
 use crate::{debug, operations::bitcoin::balance::get_blockchain};
 
 pub async fn sign_psbt(
-    wallet: &Wallet<MemoryDatabase>,
+    wallet: &Wallet<AnyDatabase>,
     mut psbt: PartiallySignedTransaction,
 ) -> Result<Transaction> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;

--- a/src/operations/rgb/send_tokens.rs
+++ b/src/operations/rgb/send_tokens.rs
@@ -4,9 +4,10 @@ use std::str::FromStr;
 use amplify::hex::ToHex;
 use amplify::Wrapper;
 use anyhow::{anyhow, Result};
+use bdk::database::AnyDatabase;
 use bdk::LocalUtxo;
 // use bdk::sled::Serialize;
-use bdk::{database::MemoryDatabase, descriptor::Descriptor, Wallet};
+use bdk::{descriptor::Descriptor, Wallet};
 use bitcoin::{psbt::serialize::Serialize, OutPoint, Transaction, Txid};
 use bp::dbc::anchor::PsbtEmbeddedMessage;
 use bp::seals::txout::{CloseMethod, ExplicitSeal};
@@ -458,9 +459,9 @@ pub async fn transfer_asset(
     blinded_utxo: &str,
     amount: u64,
     asset_contract: &str, // rgb1...
-    full_wallet: &Wallet<MemoryDatabase>,
-    // full_change_wallet: &Wallet<MemoryDatabase>,
-    assets_wallet: &Wallet<MemoryDatabase>,
+    full_wallet: &Wallet<AnyDatabase>,
+    // full_change_wallet: &Wallet<AnyDatabase>,
+    assets_wallet: &Wallet<AnyDatabase>,
     rgb_tokens_descriptor: &str,
 ) -> Result<(ConsignmentDetails, Transaction, TransferResponse)> {
     // BDK


### PR DESCRIPTION
Currently fails with:

```
 DEBUG bitmask_core::operations::bitcoin::balance    > Descriptor hash: 2b459d3f8581dcbb10c9ccc06d97445dd104df3c3607261f71a72b4dcdb59fc1
 DEBUG sled::pagecache::iterator                     > ordering before clearing tears: {0: 0}, max_header_stable_lsn: 0
 DEBUG sled::pagecache::iterator                     > in clean_tail_tears, found missing item in tail: None and we'll scan segments {0: 0} above lowest lsn 0
 DEBUG sled::pagecache::iterator                     > filtering out segments after detected tear at (lsn, lid) 99709
 DEBUG sled::pagecache::iterator                     > hit max_lsn 99709 in iterator, stopping
 DEBUG sled::pagecache::snapshot                     > zeroing the end of the recovered segment at lsn 0 between lids 99710 and 524287
 DEBUG sled::pagecache::blob_io                      > gc_blobs removing any blob with an lsn above 99710
 DEBUG sled::pagecache::segment                      > SA starting with tip 524288 stable -1 free {}
 DEBUG sled::pagecache::iobuf                        > starting log at recovered active offset 99710, recovered lsn 99710
 DEBUG sled::pagecache::iobuf                        > starting IoBufs with next_lsn: 99710 next_lid: 99710
 DEBUG sled::pagecache                               > load_snapshot loading pages from 0..79
 DEBUG sled::meta                                    > allocated pid 80 for root of new_tree [43, 69, 157, 63, 133, 129, 220, 187, 16, 201, 204, 192, 109, 151, 68, 93, 209, 4, 223, 60, 54, 7, 38, 31, 113, 167, 43, 77, 205, 181, 159, 193]
 DEBUG sled::pagecache::iobuf                        > advancing offset within the current segment from 99710 to 99905
 DEBUG sled::pagecache::iobuf                        > wrote lsns 99710-99904 to disk at offsets 99710-99904, maxed false complete_len 195
 DEBUG sled::pagecache::iobuf                        > mark_interval(99710, 195)
 DEBUG sled::pagecache::iobuf                        > new highest interval: 99710 - 99904
 DEBUG sled::pagecache::iobuf                        > make_stable(99904) returning
 DEBUG bitmask_core::operations::bitcoin::balance    > Descriptor hash: bf69dbe2e9eeff074c31e73ebc947b23be00dbf14cdcf233235e3554d84c1009
 DEBUG sled::pagecache::iobuf                        > advancing offset within the current segment from 99905 to 99947
 DEBUG sled::pagecache::iobuf                        > wrote lsns 99905-99946 to disk at offsets 99905-99946, maxed false complete_len 42
 DEBUG sled::pagecache::iobuf                        > mark_interval(99905, 42)
 DEBUG sled::pagecache::iobuf                        > new highest interval: 99905 - 99946
 DEBUG sled::pagecache::iobuf                        > make_stable(99946) returning
 DEBUG sled::pagecache::logger                       > IoBufs dropped
test asset_import ... FAILED

failures:

---- asset_import stdout ----
Error: IO error: could not acquire lock on "/home/hunter/.local/share/bitmask/wallet_db/db": Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```