### PR TITLE
Embedded RGB fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "getrandom 0.2.7",
  "gloo-console",
  "gloo-net",
+ "hex",
  "js-sys",
  "lazy_static",
  "lnpbp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sqlite = []
 
 [dependencies]
 anyhow = "1.0.44"
+base64 = { package = "base64-compat", version = "1.0.0" }
 bip39 = "1.0.1"
 bitcoin = "0.28.1"
 console_error_panic_hook = "0.1.6"
@@ -27,7 +28,7 @@ descriptor-wallet = { version = "0.8.3", features = ["descriptors", "serde"] }
 directories = "4.0"
 futures = "0.3.17"
 getrandom = { version = "0.2.3", features = ["js"] }
-base64 = { package = "base64-compat", version = "1.0.0" }
+hex = "0.4.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 once_cell = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ regex = "1"
 serde = "1.0.130"
 serde_json = "1.0.68"
 serde-encrypt = "0.7.0"
-tokio = { version = "1.20.1" }
+tokio = { version = "1.20.1", features = ["macros"] }
 pretty_env_logger = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -86,4 +86,4 @@ strict_encoding = { version = "0.8.1", features = [
 wasm-bindgen-test = "0.3.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["full"] }

--- a/src/data/constants.rs
+++ b/src/data/constants.rs
@@ -44,12 +44,11 @@ pub static NODE_SERVER_BASE_URL: Lazy<String> = Lazy::new(|| dot_env("NODE_SERVE
 
 // Descriptor strings
 // For SATS
-pub const BTC_PATH: &str = "m/86h/1h/0h/0";
-pub const BTC_CHANGE_PATH: &str = "m/86h/1h/0h/1";
+pub const BTC_PATH: &str = "m/86h/1h/0h";
 // For TOKENS ---> that's provisional, it will be replace for RGB final guidelines
-pub const RGB_TOKENS_PATH: &str = "m/168h/20h/0h/0h";
+pub const RGB_ASSETS_PATH: &str = "m/168h/20h/0h";
 // For UDAS ---> that's provisional, it will be replace for RGB final guidelines
-pub const RGB_NFTS_PATH: &str = "m/168h/21h/0h/0h";
+pub const RGB_UDAS_PATH: &str = "m/168h/21h/0h";
 
 pub static NETWORK: Lazy<RwLock<Network>> = Lazy::new(|| {
     RwLock::new(Network::Testnet) // TODO: Change default to mainnet

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -1,6 +1,19 @@
 use bitcoin::{util::address::Address, OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultData {
+    pub btc_descriptor: String,
+    pub btc_change_descriptor: String,
+    pub rgb_assets_descriptor: String,
+    pub rgb_assets_change_descriptor: String,
+    pub rgb_udas_descriptor: String,
+    pub rgb_udas_change_descriptor: String,
+    pub xpubkh: String,
+    pub mnemonic: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Issue {
     pub id: String,

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -14,6 +14,15 @@ pub struct VaultData {
     pub mnemonic: String,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct FundVaultDetails {
+    pub txid: String,
+    pub assets: String,
+    pub assets_change: String,
+    pub udas: String,
+    pub udas_change: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Issue {
     pub id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ pub mod web;
 
 use data::{
     constants,
-    structs::{AssetResponse, SatsInvoice, ThinAsset, TransferResponse, VaultData},
+    structs::{
+        AssetResponse, FundVaultDetails, SatsInvoice, ThinAsset, TransferResponse, VaultData,
+    },
 };
 
 use operations::{
@@ -222,6 +224,7 @@ pub fn set_blinded_utxo(utxo_string: &str) -> Result<BlindingUtxo> {
         txid: Txid::from_str(split.next().unwrap())?,
         vout: split.next().unwrap().to_string().parse::<u32>()?,
     };
+
     let (blind, utxo) = blind_utxo(utxo)?;
 
     let blinding_utxo = BlindingUtxo {
@@ -232,6 +235,22 @@ pub fn set_blinded_utxo(utxo_string: &str) -> Result<BlindingUtxo> {
 
     Ok(blinding_utxo)
 }
+
+// pub fn get_blinded_utxo(rgb_descriptor: &str, rgb_change_descriptor: &str) -> Result<BlindingUtxo> {
+//     let rgb_wallet = get_wallet(rgb_descriptor, rgb_change_descriptor)?;
+
+//     // ensure there's always a receive utxo
+
+//     let (blind, utxo) = blind_utxo(utxo)?;
+
+//     let blinding_utxo = BlindingUtxo {
+//         conceal: blind.conceal,
+//         blinding: blind.blinding,
+//         utxo,
+//     };
+
+//     Ok(blinding_utxo)
+// }
 
 pub async fn send_sats(
     descriptor: &str,
@@ -253,15 +272,6 @@ pub async fn send_sats(
     .await?;
 
     Ok(transaction)
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct FundVaultDetails {
-    pub txid: String,
-    pub send_assets: String,
-    pub recv_assets: String,
-    pub send_udas: String,
-    pub recv_udas: String,
 }
 
 pub async fn fund_wallet(
@@ -305,10 +315,10 @@ pub async fn fund_wallet(
 
     Ok(FundVaultDetails {
         txid: txid.to_string(),
-        send_assets: outputs[0].clone(),
-        recv_assets: outputs[1].clone(),
-        send_udas: outputs[2].clone(),
-        recv_udas: outputs[3].clone(),
+        assets: outputs[0].clone(),
+        assets_change: outputs[1].clone(),
+        udas: outputs[2].clone(),
+        udas_change: outputs[3].clone(),
     })
 }
 
@@ -330,10 +340,10 @@ pub async fn get_assets_vault(
 
             Ok(FundVaultDetails {
                 txid,
-                send_assets: output.clone(), // TODO: Make it work with other UTXOs
-                recv_assets: output.clone(),
-                send_udas: output.clone(),
-                recv_udas: output,
+                assets: output.clone(), // TODO: Make it work with other UTXOs
+                assets_change: output.clone(),
+                udas: output.clone(),
+                udas_change: output,
             })
         }
         None => Err(anyhow!("No asset UTXOs")),

--- a/src/operations/bitcoin.rs
+++ b/src/operations/bitcoin.rs
@@ -4,6 +4,6 @@ mod send_sats;
 mod sign_psbt;
 
 pub use balance::{get_wallet, synchronize_wallet};
-pub use secret::{get_mnemonic, save_mnemonic};
+pub use secret::{new_mnemonic, save_mnemonic};
 pub use send_sats::create_transaction;
 pub use sign_psbt::sign_psbt;

--- a/src/operations/bitcoin/balance.rs
+++ b/src/operations/bitcoin/balance.rs
@@ -41,10 +41,11 @@ pub fn get_wallet(
 
     #[cfg(target_arch = "wasm32")]
     let db = AnyDatabase::Memory(MemoryDatabase::default());
-
     debug!(format!("Using database: {db:?}"));
 
     let wallet = Wallet::new(descriptor, change_descriptor, *NETWORK.read().unwrap(), db)?;
+    debug!(format!("Using wallet: {wallet:?}"));
+
     Ok(wallet)
 }
 

--- a/src/operations/bitcoin/balance.rs
+++ b/src/operations/bitcoin/balance.rs
@@ -10,10 +10,7 @@ use crate::{
     debug,
 };
 
-pub fn get_wallet(
-    descriptor: &str,
-    change_descriptor: Option<&str>,
-) -> Result<Wallet<AnyDatabase>> {
+pub fn get_wallet(descriptor: &str, change_descriptor: &str) -> Result<Wallet<AnyDatabase>> {
     #[cfg(feature = "webp")]
     #[cfg(not(target_arch = "wasm32"))]
     let db = {
@@ -44,7 +41,12 @@ pub fn get_wallet(
 
     debug!(format!("Using database: {db:?}"));
 
-    let wallet = Wallet::new(descriptor, change_descriptor, *NETWORK.read().unwrap(), db)?;
+    let wallet = Wallet::new(
+        descriptor,
+        Some(change_descriptor),
+        *NETWORK.read().unwrap(),
+        db,
+    )?;
     Ok(wallet)
 }
 

--- a/src/operations/bitcoin/secret.rs
+++ b/src/operations/bitcoin/secret.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bdk::{
     bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey, KeySource},
     keys::{DerivableKey, DescriptorKey, DescriptorKey::Secret as SecretDesc},
@@ -12,7 +12,10 @@ use bitcoin::secp256k1::Secp256k1;
 // use psbt::sign::MemorySigningAccount;
 // use wallet::hd::{standards::DerivationBlockchain, Bip43, DerivationStandard};
 
-use crate::data::constants::{BTC_CHANGE_PATH, BTC_PATH, NETWORK, RGB_NFTS_PATH, RGB_TOKENS_PATH};
+use crate::data::{
+    constants::{BTC_PATH, NETWORK, RGB_ASSETS_PATH, RGB_UDAS_PATH},
+    structs::VaultData,
+};
 
 fn get_random_buf() -> Result<[u8; 16], getrandom::Error> {
     let mut buf = [0u8; 16];
@@ -20,103 +23,60 @@ fn get_random_buf() -> Result<[u8; 16], getrandom::Error> {
     Ok(buf)
 }
 
-fn get_descriptor<C: ScriptContext>(xprv: ExtendedPrivKey, path: &str, xpub: bool) -> String {
+fn get_descriptor<C: ScriptContext>(xprv: ExtendedPrivKey, path: &str) -> Result<String> {
     let secp = Secp256k1::new();
-    let deriv_descriptor: DerivationPath = DerivationPath::from_str(path).unwrap();
-    let derived_xprv = &xprv.derive_priv(&secp, &deriv_descriptor).unwrap();
-
+    let deriv_descriptor: DerivationPath = DerivationPath::from_str(path)?;
+    let derived_xprv = &xprv.derive_priv(&secp, &deriv_descriptor)?;
     let origin: KeySource = (xprv.fingerprint(&secp), deriv_descriptor);
-
-    let derived_xprv_desc_key: DescriptorKey<C> = derived_xprv
-        .into_descriptor_key(Some(origin), DerivationPath::default())
-        .unwrap();
+    let derived_xprv_desc_key: DescriptorKey<C> =
+        derived_xprv.into_descriptor_key(Some(origin), DerivationPath::default())?;
 
     if let SecretDesc(desc_seckey, _, _) = derived_xprv_desc_key {
-        let desc_pubkey = desc_seckey.as_public(&secp).unwrap();
-        if xpub {
-            desc_pubkey.to_string()
-        } else {
-            desc_seckey.to_string()
-        }
+        let desc_pubkey = desc_seckey.as_public(&secp)?;
+        Ok(desc_pubkey.to_string())
     } else {
-        "Invalid key variant".to_string()
+        Err(anyhow!("Invalid key variant"))
     }
 }
 
-// fn get_rgb_descriptor(network: &str, master_xpriv: ExtendedPrivKey, path: u32) -> String {
-//     let secp = Secp256k1::new();
-//     let master_xpub = ExtendedPubKey::from_priv(&secp, &master_xpriv);
-//     let scheme = Bip43::Bip86;
-//     let blockchain = DerivationBlockchain::from_str(network).unwrap();
-//     let derivation =
-//         scheme.to_account_derivation(ChildNumber::from_hardened_idx(path).unwrap(), blockchain);
-//     let account_xpriv = master_xpriv.derive_priv(&secp, &derivation).unwrap();
-//     let account =
-//         MemorySigningAccount::with(&secp, master_xpub.identifier(), derivation, account_xpriv);
-//     let descriptor = account.recommended_descriptor();
-//     descriptor.unwrap().to_string()
-// }
-
-pub fn get_mnemonic(seed_password: &str) -> (String, String, String, String, String, String) {
-    let entropy = get_random_buf().expect("Get browser entropy");
-    let mnemonic_phrase =
-        Mnemonic::from_entropy(&entropy).expect("New mnemonic from browser entropy");
-
-    let seed = mnemonic_phrase.to_seed_normalized(seed_password);
-
-    let network = NETWORK.read().unwrap();
-    let xprv = ExtendedPrivKey::new_master(*network, &seed).expect("New xprivkey from seed");
-
-    let btc_descriptor = format!("tr({})", get_descriptor::<Tap>(xprv, BTC_PATH, false));
-    let btc_change_descriptor = format!(
-        "tr({})",
-        get_descriptor::<Tap>(xprv, BTC_CHANGE_PATH, false)
-    );
-    let rgb_tokens_descriptor =
-        format!("tr({})", get_descriptor::<Tap>(xprv, RGB_TOKENS_PATH, true));
-    let rgb_nfts_descriptor = format!("tr({})", get_descriptor::<Tap>(xprv, RGB_NFTS_PATH, true));
-
-    let secp = Secp256k1::new();
-    let xpub = ExtendedPubKey::from_priv(&secp, &xprv);
-
-    (
-        mnemonic_phrase.to_string(),
-        btc_descriptor,
-        btc_change_descriptor,
-        rgb_tokens_descriptor,
-        rgb_nfts_descriptor,
-        xpub.to_pub().pubkey_hash().to_string(),
-    )
+pub fn new_mnemonic(seed_password: &str) -> Result<VaultData> {
+    let entropy = get_random_buf()?;
+    let mnemonic_phrase = Mnemonic::from_entropy(&entropy)?;
+    get_mnemonic(mnemonic_phrase, seed_password)
 }
 
-pub fn save_mnemonic(
-    seed_password: &str,
-    mnemonic: &str,
-) -> (String, String, String, String, String) {
+pub fn save_mnemonic(seed_password: &str, mnemonic: &str) -> Result<VaultData> {
     let mnemonic_phrase = Mnemonic::from_str(mnemonic).expect("Parse mnemonic seed phrase");
+    get_mnemonic(mnemonic_phrase, seed_password)
+}
 
+pub fn get_mnemonic(mnemonic_phrase: Mnemonic, seed_password: &str) -> Result<VaultData> {
     let seed = mnemonic_phrase.to_seed_normalized(seed_password);
 
     let network = NETWORK.read().unwrap();
-    let xprv = ExtendedPrivKey::new_master(*network, &seed).expect("New xprivkey from seed");
+    let xprv = ExtendedPrivKey::new_master(*network, &seed)?;
 
-    let btc_descriptor = format!("tr({})", get_descriptor::<Tap>(xprv, BTC_PATH, false));
-    let btc_change_descriptor = format!(
-        "tr({})",
-        get_descriptor::<Tap>(xprv, BTC_CHANGE_PATH, false)
-    );
-    let rgb_tokens_descriptor =
-        format!("tr({})", get_descriptor::<Tap>(xprv, RGB_TOKENS_PATH, true));
-    let rgb_nfts_descriptor = format!("tr({})", get_descriptor::<Tap>(xprv, RGB_NFTS_PATH, true));
+    let btc_descriptor = format!("tr({}/0/*)", get_descriptor::<Tap>(xprv, BTC_PATH)?);
+    let btc_change_descriptor = format!("tr({}/1/*)", get_descriptor::<Tap>(xprv, BTC_PATH)?);
+    let rgb_assets_descriptor =
+        format!("tr({}/0/*)", get_descriptor::<Tap>(xprv, RGB_ASSETS_PATH)?);
+    let rgb_assets_change_descriptor =
+        format!("tr({}/1/*)", get_descriptor::<Tap>(xprv, RGB_ASSETS_PATH)?);
+    let rgb_udas_descriptor = format!("tr({}/0/*)", get_descriptor::<Tap>(xprv, RGB_UDAS_PATH)?);
+    let rgb_udas_change_descriptor =
+        format!("tr({}/1/*)", get_descriptor::<Tap>(xprv, RGB_UDAS_PATH)?);
 
     let secp = Secp256k1::new();
     let xpub = ExtendedPubKey::from_priv(&secp, &xprv);
 
-    (
+    Ok(VaultData {
         btc_descriptor,
         btc_change_descriptor,
-        rgb_tokens_descriptor,
-        rgb_nfts_descriptor,
-        xpub.to_pub().pubkey_hash().to_string(),
-    )
+        rgb_assets_descriptor,
+        rgb_assets_change_descriptor,
+        rgb_udas_descriptor,
+        rgb_udas_change_descriptor,
+        xpubkh: xpub.to_pub().pubkey_hash().to_string(),
+        mnemonic: mnemonic_phrase.to_string(),
+    })
 }

--- a/src/operations/bitcoin/sign_psbt.rs
+++ b/src/operations/bitcoin/sign_psbt.rs
@@ -8,6 +8,7 @@ pub async fn sign_psbt(
     wallet: &Wallet<AnyDatabase>,
     mut psbt: PartiallySignedTransaction,
 ) -> Result<Transaction> {
+    debug!("Signing PSBT...");
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     if finalized {
         debug!("Signed PSBT:", base64::encode(&serialize(&psbt)));

--- a/src/operations/rgb.rs
+++ b/src/operations/rgb.rs
@@ -10,7 +10,7 @@ mod validate_transaction;
 pub use accept_transaction::accept_transfer;
 pub use create_psbt::create_psbt;
 // pub use descriptor_wallet::rgb_address;
-pub use import_asset::{get_asset_by_contract_id, get_asset_by_genesis, get_assets};
+pub use import_asset::{get_asset_by_genesis, get_assets};
 pub use issue_asset::issue_asset;
 pub use receive_tokens::blind_utxo;
 pub use send_tokens::{transfer_asset, ConsignmentDetails};

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,19 +120,3 @@ pub async fn post_json<T: Serialize>(url: String, body: &T) -> Result<(String, u
 
     Ok((response_text, status_code))
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn get(url: String) -> Result<(String, u16)> {
-    let response = reqwest::get(&url)
-        .await
-        .context(format!("Error sending GET request to {}", url))?;
-
-    let status_code = response.status().as_u16();
-
-    let response_text = response
-        .text()
-        .await
-        .context("Error in handling server response")?;
-
-    Ok((response_text, status_code))
-}

--- a/src/web.rs
+++ b/src/web.rs
@@ -99,10 +99,13 @@ pub fn get_wallet_data(descriptor: String, change_descriptor: Option<String>) ->
 }
 
 #[wasm_bindgen]
-pub fn import_list_assets(node_url: Option<String>) -> Promise {
+pub fn import_list_assets(xpubkh: String, encryption_secret: String, node_url: Option<String>) -> Promise {
     set_panic_hook();
 
     future_to_promise(async move {
+        todo!("make call to storage lambda, decrypt, then pass to import_list_assets");
+        let result = get(url(node_url)).await;
+
         match crate::import_list_assets(node_url).await {
             Ok(result) => Ok(JsValue::from_string(
                 serde_json::to_string(&result).unwrap(),

--- a/tests/asset.rs
+++ b/tests/asset.rs
@@ -70,7 +70,7 @@ async fn asset_import() -> Result<()> {
     {
         Ok(fund_vault_details) => {
             info!("Found existing UTXO");
-            fund_vault_details.send_assets
+            fund_vault_details.assets
         }
         Err(err) => {
             info!("Funding vault... {}", err);
@@ -83,7 +83,7 @@ async fn asset_import() -> Result<()> {
             .await?;
             debug!("Fund vault details: {fund_vault_details:#?}");
 
-            fund_vault_details.send_assets
+            fund_vault_details.assets
         }
     };
 

--- a/tests/asset.rs
+++ b/tests/asset.rs
@@ -5,7 +5,7 @@ use std::env;
 use anyhow::Result;
 use bitmask_core::{
     create_asset, fund_wallet, get_assets_vault, get_network, /* get_rgb_address,*/ get_vault,
-    get_wallet_data, import_asset, save_mnemonic_seed, send_tokens, set_blinded_utxo,
+    get_wallet_data, import_asset, save_mnemonic_seed, send_assets, set_blinded_utxo,
 };
 use log::{debug, info};
 
@@ -33,14 +33,14 @@ async fn asset_import() -> Result<()> {
     let mnemonic = env!("TEST_WALLET_SEED", "TEST_WALLET_SEED variable not set");
     let mnemonic_data = save_mnemonic_seed(mnemonic, ENCRYPTION_PASSWORD, SEED_PASSWORD)?;
 
-    let encrypted_descriptors = serde_json::to_string(&mnemonic_data.serialized_encrypted_message)?;
-
     info!("Get vault properties");
-    let vault = get_vault(ENCRYPTION_PASSWORD, &encrypted_descriptors)?;
+    let vault = get_vault(
+        ENCRYPTION_PASSWORD,
+        &mnemonic_data.serialized_encrypted_message,
+    )?;
 
     info!("Get assets wallet data");
-    let btc_wallet =
-        get_wallet_data(&vault.btc_descriptor, Some(&vault.btc_change_descriptor)).await?;
+    let btc_wallet = get_wallet_data(&vault.btc_descriptor, &vault.btc_change_descriptor).await?;
 
     assert!(
         !btc_wallet.transactions.is_empty(),
@@ -48,13 +48,26 @@ async fn asset_import() -> Result<()> {
     );
 
     info!("Get assets wallet data");
-    let assets_wallet = get_wallet_data(&vault.rgb_tokens_descriptor, None).await?;
+    let assets_wallet = get_wallet_data(
+        &vault.rgb_assets_descriptor,
+        &vault.rgb_assets_change_descriptor,
+    )
+    .await?;
 
     info!("Get UDAs wallet data");
-    let udas_wallet = get_wallet_data(&vault.rgb_nfts_descriptor, None).await?;
+    let udas_wallet = get_wallet_data(
+        &vault.rgb_udas_descriptor,
+        &vault.rgb_udas_change_descriptor,
+    )
+    .await?;
 
     info!("Check assets vault");
-    let send_assets = match get_assets_vault(&vault.rgb_tokens_descriptor).await {
+    let send_assets_utxo = match get_assets_vault(
+        &vault.rgb_assets_descriptor,
+        &vault.rgb_assets_change_descriptor,
+    )
+    .await
+    {
         Ok(fund_vault_details) => {
             info!("Found existing UTXO");
             fund_vault_details.send_assets
@@ -75,32 +88,27 @@ async fn asset_import() -> Result<()> {
     };
 
     info!("Create a test asset");
-    let issued_asset = &create_asset(TICKER, NAME, PRECISION, SUPPLY, &send_assets)?;
+    let issued_asset = &create_asset(TICKER, NAME, PRECISION, SUPPLY, &send_assets_utxo)?;
 
     let asset_data = serde_json::to_string_pretty(&issued_asset)?;
     debug!("Asset data: {asset_data}");
 
     info!("Import asset");
-    let imported_asset = import_asset(
-        Some(&vault.rgb_tokens_descriptor),
-        None,
-        Some(&issued_asset.genesis),
-        None,
-    )
-    .await?;
+    let imported_asset = import_asset(&issued_asset.genesis)?;
 
     assert_eq!(issued_asset.asset_id, imported_asset.id, "Asset IDs match");
 
     info!("Get a blinded UTXO");
-    let blinded_utxo = set_blinded_utxo(&send_assets)?;
+    let blinded_utxo = set_blinded_utxo(&send_assets_utxo)?;
 
     debug!("Blinded UTXO: {:?}", blinded_utxo);
 
     info!("Transfer asset");
-    let consignment_details = send_tokens(
+    let consignment_details = send_assets(
         &vault.btc_descriptor,
-        // &vault.btc_change_descriptor,
-        &vault.rgb_tokens_descriptor,
+        &vault.btc_change_descriptor,
+        &vault.rgb_assets_descriptor,
+        &vault.rgb_assets_change_descriptor,
         &blinded_utxo.conceal,
         100,
         &issued_asset.genesis,


### PR DESCRIPTION
Includes API changes from earlier this week, plus solves some issues in asset transfer, and includes latest changes from both of Zoe's PRs in rgb-node:
- https://github.com/RGB-WG/rgb-node/pull/196
- https://github.com/RGB-WG/rgb-node/pull/195

To be clear, the code duplication arrangement is temporary until we can build & contribute Embedded Storm upstream (zmq inproc / in-memory btreemap instead of sled).

The code here only fails because BDK fails to sign the PSBT because it fails to satisfy some condition. It's possible we'll need to use the RGB descriptor wallet to sign and broadcast the PSBT.