### PR TITLE
Send PayJoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip21"
+version = "0.1.2"
+source = "git+https://github.com/DanGould/bip21.git?rev=f74dd0f#f74dd0fb452f7d1e25f2b2d892a170f76f59f752"
+dependencies = [
+ "bitcoin",
+ "percent-encoding-rfc3986",
+]
+
+[[package]]
 name = "bip39"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +382,17 @@ dependencies = [
  "rand_core 0.4.2",
  "serde",
  "unicode-normalization",
+]
+
+[[package]]
+name = "bip78"
+version = "0.2.0-preview"
+source = "git+https://github.com/dangould/rust-payjoin?rev=8d9b7d6#8d9b7d6ee5907b068a54bf65fd6ad5744c402756"
+dependencies = [
+ "base64",
+ "bip21",
+ "bitcoin",
+ "url",
 ]
 
 [[package]]
@@ -471,6 +491,7 @@ dependencies = [
  "bdk",
  "bech32 0.9.1",
  "bip39",
+ "bip78",
  "bitcoin",
  "bitcoin_hashes 0.10.0",
  "bp-core",
@@ -2189,6 +2210,12 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "pin-project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "1.0"
 base64 = { package = "base64-compat", version = "1.0" }
 bech32 = "0.9"
 bip39 = "1.0"
+bip78 = { git = "https://github.com/dangould/rust-payjoin", rev = "8d9b7d6", features = ["sender" ] }
 bitcoin = "0.28.1"
 bitcoin_hashes = "0.10.0"
 console_error_panic_hook = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod util;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
 
+use crate::operations::bitcoin::create_payjoin;
 // Desktop
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::{
@@ -399,19 +400,37 @@ pub async fn get_blinded_utxo(utxo_string: &str) -> Result<BlindingUtxo> {
 pub async fn send_sats(
     descriptor: &str,
     change_descriptor: &str,
-    address: &str,
+    destination: &str, // bip21 uri or address
     amount: u64,
     fee_rate: Option<f32>,
 ) -> Result<Transaction> {
-    let address = Address::from_str(address)?;
+    use bip78::UriExt;
 
     let wallet = get_wallet(descriptor, Some(change_descriptor.to_owned()))?;
     synchronize_wallet(&wallet).await?;
 
     let fee_rate = fee_rate.map(FeeRate::from_sat_per_vb);
 
-    let transaction =
-        create_transaction(vec![SatsInvoice { address, amount }], &wallet, fee_rate).await?;
+    let transaction = match bip78::Uri::try_from(destination) {
+        Ok(uri) => {
+            let address = uri.address.clone();
+            if let Ok(pj_uri) = uri.check_pj_supported() {
+                create_payjoin(
+                    vec![SatsInvoice { address, amount }],
+                    &wallet,
+                    fee_rate,
+                    pj_uri,
+                )
+                .await?
+            } else {
+                create_transaction(vec![SatsInvoice { address, amount }], &wallet, fee_rate).await?
+            }
+        }
+        _ => {
+            let address = Address::from_str(destination)?;
+            create_transaction(vec![SatsInvoice { address, amount }], &wallet, fee_rate).await?
+        }
+    };
 
     Ok(transaction)
 }

--- a/src/operations/bitcoin.rs
+++ b/src/operations/bitcoin.rs
@@ -7,5 +7,5 @@ mod sign_psbt;
 pub use assets::dust_tx;
 pub use balance::{get_wallet, synchronize_wallet};
 pub use secret::{new_mnemonic, save_mnemonic};
-pub use send_sats::create_transaction;
+pub use send_sats::{create_payjoin, create_transaction};
 pub use sign_psbt::sign_psbt;

--- a/src/operations/bitcoin/sign_psbt.rs
+++ b/src/operations/bitcoin/sign_psbt.rs
@@ -4,6 +4,7 @@ use bitcoin::{consensus::serialize, util::psbt::PartiallySignedTransaction, Tran
 
 use crate::{debug, operations::bitcoin::balance::get_blockchain};
 
+/// signs and broadcasts a transaction given a Psbt
 pub async fn sign_psbt(
     wallet: &Wallet<AnyDatabase>,
     mut psbt: PartiallySignedTransaction,
@@ -21,4 +22,19 @@ pub async fn sign_psbt(
     } else {
         Err(Error::msg("Could not finalize when signing PSBT"))
     }
+}
+
+// Only signs an original psbt.
+pub async fn sign_original_psbt(
+    wallet: &Wallet<AnyDatabase>,
+    mut psbt: PartiallySignedTransaction,
+) -> Result<PartiallySignedTransaction> {
+    debug!("Funding PSBT...");
+    let opts = SignOptions {
+        remove_partial_sigs: false,
+        try_finalize: false,
+        ..Default::default()
+    };
+    wallet.sign(&mut psbt, opts)?;
+    Ok(psbt)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -144,14 +144,14 @@ pub fn get_blinded_utxo(utxo_string: String) -> Promise {
 pub fn send_sats(
     descriptor: String,
     change_descriptor: String,
-    address: String,
+    destination: String,
     amount: u64,
     fee_rate: Option<f32>,
 ) -> Promise {
     set_panic_hook();
 
     future_to_promise(async move {
-        match crate::send_sats(&descriptor, &change_descriptor, &address, amount, fee_rate).await {
+        match crate::send_sats(&descriptor, &change_descriptor, &destination, amount, fee_rate).await {
             Ok(result) => Ok(JsValue::from_string(
                 serde_json::to_string(&result).unwrap(),
             )),


### PR DESCRIPTION
Change interface to accept a bip21 PjUri as defined in bip78. Only use address from the bip21 Uri, still pass amount in as a separate argument to send_sats.

I think the design choices to consider are mostly around passing how we'd like to pass the bip21 from send_sats. Where is the web interface that uses this?

The other question is whether or not to finalize and broadcast the original_psbt in the case of an unresponsive pj endpoint.

This was my first time handling errors in rust with anyhow. Wow, much ease!

May I please have some testnet sats tb1pn4g2sjt0qw9t43lj28quhnajs064n8frzalqjqueuvcas4h6hxlsau59qd ? I can't find a faucet to pay a bitmask taproot address. so futuristic.

You can get a bip21 receiver for this payjoin sender at https://testnet.demo.btcpayserver.org/login to test on testnet