### PR TITLE
Fix clippy lints ca. rustc 1.66

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub fn get_mnemonic_seed(
 
     let encrypted_wallet_data = new_mnemonic(seed_password)?;
     let encrypted_message = encrypted_wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let serialized_encrypted_message = hex::encode(&encrypted_message.serialize());
+    let serialized_encrypted_message = hex::encode(encrypted_message.serialize());
     let mnemonic_seed_data = MnemonicSeedData {
         mnemonic: encrypted_wallet_data.mnemonic,
         serialized_encrypted_message,
@@ -118,7 +118,7 @@ pub fn save_mnemonic_seed(
 
     let vault_data = save_mnemonic(mnemonic_phrase, seed_password)?;
     let encrypted_message = vault_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let serialized_encrypted_message = hex::encode(&encrypted_message.serialize());
+    let serialized_encrypted_message = hex::encode(encrypted_message.serialize());
     let mnemonic_seed_data = MnemonicSeedData {
         mnemonic: vault_data.mnemonic,
         serialized_encrypted_message,

--- a/src/operations/rgb/accept_transaction.rs
+++ b/src/operations/rgb/accept_transaction.rs
@@ -39,7 +39,7 @@ pub async fn accept_transfer(
         method: reveal.close_method,
         blinding: reveal.blinding_factor,
         txid: Some(reveal.outpoint.txid),
-        vout: reveal.outpoint.vout as u32,
+        vout: reveal.outpoint.vout,
     };
 
     let concealed_seals = consignment

--- a/src/operations/rgb/send_tokens.rs
+++ b/src/operations/rgb/send_tokens.rs
@@ -450,7 +450,7 @@ pub async fn transfer_asset(
     ));
     debug!(format!(
         "Finalized PSBT to be signed (hex): {}",
-        hex::encode(&psbt.serialize())
+        hex::encode(psbt.serialize())
     ));
     debug!(format!(
         "RGB assets descriptor from BDK {bdk_rgb_assets_descriptor_xpub}"

--- a/src/operations/rgb/shared.rs
+++ b/src/operations/rgb/shared.rs
@@ -253,7 +253,7 @@ async fn process_consignment<C: ConsignmentType>(
             method: close_method,
             blinding: blinding_factor,
             txid: Some(outpoint.txid),
-            vout: outpoint.vout as u32,
+            vout: outpoint.vout,
         };
 
         let concealed_seals = consignment
@@ -339,7 +339,7 @@ async fn process_consignment<C: ConsignmentType>(
                         method: close_method,
                         blinding: blinding_factor,
                         txid: Some(outpoint.txid),
-                        vout: outpoint.vout as u32,
+                        vout: outpoint.vout,
                     };
 
                     let mut owned_rights: BTreeMap<OwnedRightType, TypedAssignments> = bmap! {};


### PR DESCRIPTION
This fixes issues raised in CI on the latest version of Rust stable channel.