### PR TITLE
Add xpubkh to EncryptedWalletData struct

### DIFF
--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -46,6 +46,7 @@ pub struct EncryptedWalletData {
     pub rgb_assets_descriptor_xpub: String,
     pub rgb_udas_descriptor_xprv: String,
     pub rgb_udas_descriptor_xpub: String,
+    pub xprvkh: String,
     pub xpubkh: String,
     pub mnemonic: String,
 }

--- a/src/operations/bitcoin/secret.rs
+++ b/src/operations/bitcoin/secret.rs
@@ -8,6 +8,7 @@ use bdk::{
 };
 use bip39::Mnemonic;
 use bitcoin::{secp256k1::Secp256k1, util::bip32::ChildNumber};
+use bitcoin_hashes::{sha256, Hash};
 
 use crate::data::{
     constants::{BTC_PATH, NETWORK, RGB_ASSETS_PATH, RGB_UDAS_PATH},
@@ -67,6 +68,7 @@ pub fn get_mnemonic(mnemonic_phrase: Mnemonic, seed_password: &str) -> Result<En
     let secp = Secp256k1::new();
     let xpub = ExtendedPubKey::from_priv(&secp, &xprv);
     let xpubkh = xpub.to_pub().pubkey_hash().to_string();
+    let xprvkh = sha256::Hash::hash(&xprv.to_priv().to_bytes()).to_string();
 
     let btc_descriptor_xprv = format!(
         "tr({})",
@@ -109,6 +111,7 @@ pub fn get_mnemonic(mnemonic_phrase: Mnemonic, seed_password: &str) -> Result<En
         rgb_assets_descriptor_xpub,
         rgb_udas_descriptor_xprv,
         rgb_udas_descriptor_xpub,
+        xprvkh,
         xpubkh,
         mnemonic: mnemonic_phrase.to_string(),
     })


### PR DESCRIPTION
This is to support username/password situations where something unique to each wallet is used as a login without revealing the keys themselves. As an example use-case, we're using it for the lndhubx login.