### PR TITLE
Update Actions CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: mastermaster
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           targets: x86_64-unknown-linux-gnu
@@ -36,12 +36,11 @@ jobs:
           targets: x86_64-unknown-linux-gnu
           components: clippy
 
-      # - uses: olix0r/cargo-action-fmt@release/v1.0.0
+      - uses: olix0r/cargo-action-fmt/setup@v2
       - uses: Swatinem/rust-cache@v2
 
       - name: Lint
-        run: cargo clippy --lib --all-features -- -D warnings
-        # run: cargo clippy --lib --all-features -q --message-format=json -- -D warnings | clippy-action-fmt
+        run: cargo clippy --lib --all-features --message-format=json -- -D warnings | cargo-action-fmt
 
   lint-wasm:
     runs-on: ubuntu-latest
@@ -55,7 +54,7 @@ jobs:
           targets: wasm32-unknown-unknown
           components: clippy
 
-      # - uses: olix0r/cargo-action-fmt@release/v1.0.0
+      - uses: olix0r/cargo-action-fmt/setup@v2
       - uses: jetli/wasm-pack-action@v0.3.0
       - uses: Swatinem/rust-cache@v2
 
@@ -63,8 +62,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Lint (wasm32)
-        run: cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings
-        # run: cargo clippy --target wasm32-unknown-unknown --lib -q --message-format=json -- -D warnings | clippy-action-fmt
+        run: cargo clippy --target wasm32-unknown-unknown --lib --message-format=json -- -D warnings | cargo-action-fmt
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: mastermaster
         with:
-          profile: minimal
           toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Check Formatting
         run: cargo fmt --all -- --check
-
 
   lint:
     runs-on: ubuntu-latest
@@ -30,10 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+          components: clippy
 
       # - uses: olix0r/cargo-action-fmt@release/v1.0.0
       - uses: Swatinem/rust-cache@v2
@@ -48,10 +49,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
+          targets: wasm32-unknown-unknown
+          components: clippy
 
       # - uses: olix0r/cargo-action-fmt@release/v1.0.0
       - uses: jetli/wasm-pack-action@v0.3.0
@@ -64,17 +66,18 @@ jobs:
         run: cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings
         # run: cargo clippy --target wasm32-unknown-unknown --lib -q --message-format=json -- -D warnings | clippy-action-fmt
 
-  isomorphic:
+  test:
     runs-on: ubuntu-latest
     needs: lint
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
@@ -99,23 +102,20 @@ jobs:
           TEST_WALLET_SEED: ${{ secrets.TEST_WALLET_SEED }}
           RUST_BACKTRACE: 1
 
-  # web:
+  # test-wasm:
   #   runs-on: ubuntu-latest
   #   needs: lint-wasm
 
   #   steps:
   #     - uses: actions/checkout@v3
 
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@master
   #       with:
-  #         profile: minimal
   #         toolchain: stable
+  #         targets: wasm32-unknown-unknown
 
   #     - uses: Swatinem/rust-cache@v2
   #     - uses: jetli/wasm-pack-action@v0.3.0
-
-  #     - name: Add wasm32 target
-  #       run: rustup target add wasm32-unknown-unknown
 
   #     - name: Test
   #       run: wasm-pack test --headless --chrome


### PR DESCRIPTION
Apparently, actions-rs is no longer being maintained, so we need to switch to a different toolchain.

This also adds some tooling that can help catch clippy fmts.