### PR TITLE
Reverting import asset and adding wasm to transfer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,13 +306,13 @@ pub fn import_asset(asset: &str, utxos: Vec<String>) -> Result<ThinAsset> {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn import_asset(asset: &str, utxo: &str) -> Result<ThinAsset> {
+pub async fn import_asset(asset: &str, utxo: &str, blinded: &str) -> Result<ThinAsset> {
     info!("Getting asset:", asset);
 
     let endpoint = &get_endpoint("import").await;
     let body = AssetRequest {
         asset: asset.to_owned(),
-        utxos: vec![utxo.to_owned()],
+        utxos: vec![utxo.to_owned(), blinded.to_owned()],
     };
     let (asset_res, status) = post_json(endpoint, &body).await?;
     if status != 200 {

--- a/src/web.rs
+++ b/src/web.rs
@@ -99,11 +99,11 @@ pub fn get_wallet_data(descriptor: String, change_descriptor: Option<String>) ->
 }
 
 #[wasm_bindgen]
-pub fn import_asset(asset: String, utxo: String) -> Promise {
+pub fn import_asset(asset: String, utxo: String, blinded: String) -> Promise {
     set_panic_hook();
 
     future_to_promise(async move {
-        match crate::import_asset(&asset, &utxo).await {
+        match crate::import_asset(&asset, &utxo, &blinded).await {
             Ok(result) => Ok(JsValue::from_string(
                 serde_json::to_string(&result).unwrap(),
             )),
@@ -216,6 +216,7 @@ pub fn create_asset(
     })
 }
 
+#[wasm_bindgen]
 pub fn transfer_assets(request: JsValue) -> Promise {
     set_panic_hook();
 


### PR DESCRIPTION
By mistake, import asset lost sending blinding and is necessary to retrieve data from lambdas.
Plus I add wasm_bindgen to transfer_assets