### PR TITLE
Allow spend inputs with tap(tweak)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_hd"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_onchain"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",
@@ -474,6 +474,7 @@ dependencies = [
  "bitcoin_scripts",
  "bp-core",
  "bp-seals",
+ "commit_verify",
  "console_error_panic_hook",
  "deflate",
  "descriptor-wallet",
@@ -866,7 +867,7 @@ dependencies = [
 [[package]]
 name = "descriptor-wallet"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",
@@ -883,7 +884,7 @@ dependencies = [
 [[package]]
 name = "descriptors"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",
@@ -1834,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "psbt"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",
@@ -2360,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "slip132"
 version = "0.10.0-alpha.2"
-source = "git+https://github.com/crisdut/descriptor-wallet?branch=release/0.10.0-alpha.2#f021bb329f193c680e29ae9d9c9454938cecb157"
+source = "git+https://github.com/crisdut/descriptor-wallet?branch=exp/tapret-transfers#889ca14c1fd225ae0c72fb9c639b0d41afc59bb7"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bitcoin_hashes = "0.11.0"
 bitcoin_scripts = "0.10.0-alpha.2"
 bitcoin_blockchain = "0.10.0-alpha.2"
 bp-core = "0.10.0"
+commit_verify = "0.10.0"
 bp-seals = "0.10.0"
 console_error_panic_hook = "0.1.7"
 # directories = "4.0.1"
@@ -108,5 +109,5 @@ wasm-bindgen-test = "0.3.33"
 # TODO: Remove this after merge and release a new version
 bitcoin_scripts = { git = "https://github.com/crisdut/bp-foundation", branch = "release/0.10.0-alpha.2" }
 bitcoin_blockchain = { git = "https://github.com/crisdut/bp-foundation", branch = "release/0.10.0-alpha.2" }
-descriptor-wallet = { git = "https://github.com/crisdut/descriptor-wallet", branch = "release/0.10.0-alpha.2" }
-psbt = { git = "https://github.com/crisdut/descriptor-wallet", branch = "release/0.10.0-alpha.2" }
+descriptor-wallet = { git = "https://github.com/crisdut/descriptor-wallet", branch = "exp/tapret-transfers" }
+psbt = { git = "https://github.com/crisdut/descriptor-wallet", branch = "exp/tapret-transfers" }

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -130,8 +130,12 @@ pub struct RgbTransferRequest {
 pub struct RgbTransferResponse {
     /// Consignment ID
     pub consig_id: String,
-    /// Consignment encoded in hexadecimal
+    /// Consignment encoded (in hexadecimal)
     pub consig: String,
+    /// SBT File Information with tapret (in hexadecimal)
+    pub psbt: String,
+    /// Tapret Commitment (used to spend output)
+    pub commit: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/data/structs.rs
+++ b/src/data/structs.rs
@@ -108,6 +108,8 @@ pub struct PsbtRequest {
     pub bitcoin_changes: Vec<String>,
     /// Bitcoin Fee
     pub fee: u64,
+    /// TapTweak used to spend outputs based in tapret commitments
+    pub input_tweak: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@ pub async fn create_psbt(request: PsbtRequest) -> Result<PsbtResponse> {
         change_index,
         bitcoin_changes,
         fee,
+        input_tweak,
     } = request;
 
     // TODO: Pull from Carbonado (?)
@@ -419,6 +420,7 @@ pub async fn create_psbt(request: PsbtRequest) -> Result<PsbtResponse> {
         change_index,
         bitcoin_changes,
         fee,
+        input_tweak,
         &tx_resolver,
     )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use data::structs::{
     InterfacesResponse, InvoiceResult, IssueResponse, PsbtRequest, PsbtResponse,
     RgbTransferRequest, RgbTransferResponse, SchemaDetail, SchemasResponse,
 };
+use operations::rgb::psbt::extract_commit;
 use operations::rgb::{
     invoice::{accept_payment, create_invoice as create_rgb_invoice, pay_invoice},
     issue::issue_contract as create_contract,
@@ -436,14 +437,18 @@ pub async fn pay_asset(request: RgbTransferRequest) -> Result<RgbTransferRespons
 
     // TODO: Pull from Carbonado
     let mut stock = Stock::default();
-    let transfer = pay_invoice(rgb_invoice, psbt, &mut stock)?;
+    let (psbt, transfer) = pay_invoice(rgb_invoice, psbt, &mut stock)?;
 
+    let commit = extract_commit(psbt.clone())?;
+    let psbt = psbt.to_string();
     let consig = RgbTransferResponse {
         consig_id: transfer.bindle_id().to_string(),
         consig: transfer
             .to_strict_serialized::<0xFFFFFF>()
             .expect("invalid transfer serialization")
             .to_hex(),
+        psbt,
+        commit,
     };
     // TODO: Push to Carbonado
     Ok(consig)

--- a/src/operations/rgb/psbt.rs
+++ b/src/operations/rgb/psbt.rs
@@ -10,7 +10,11 @@ use bp::TapScript;
 use commit_verify::mpc::Commitment;
 use commit_verify::CommitVerify;
 use miniscript_crate::Descriptor;
+use psbt::ProprietaryKey;
 use psbt::ProprietaryKeyType;
+use rgbwallet::psbt::DbcPsbtError;
+use rgbwallet::psbt::TapretKeyError;
+use rgbwallet::psbt::{PSBT_OUT_TAPRET_COMMITMENT, PSBT_OUT_TAPRET_HOST, PSBT_TAPRET_PREFIX};
 use wallet::psbt::Psbt;
 use wallet::{
     descriptors::InputDescriptor,
@@ -22,6 +26,7 @@ use wallet::{
 use super::constants::RGB_PSBT_TAPRET;
 use super::structs::AddressAmount;
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_psbt(
     descriptor_pub: String,
     asset_utxo: String,
@@ -125,4 +130,31 @@ pub fn create_psbt(
     }
 
     Ok(psbt)
+}
+
+pub fn extract_commit(mut psbt: Psbt) -> Result<String, DbcPsbtError> {
+    let (_, output) = psbt
+        .outputs
+        .iter_mut()
+        .enumerate()
+        .find(|(_, output)| {
+            output.proprietary.contains_key(&ProprietaryKey {
+                prefix: PSBT_TAPRET_PREFIX.to_vec(),
+                subtype: PSBT_OUT_TAPRET_HOST,
+                key: vec![],
+            })
+        })
+        .ok_or(DbcPsbtError::NoHostOutput)
+        .expect("");
+
+    let commit_vec = output.proprietary.get(&ProprietaryKey {
+        prefix: PSBT_TAPRET_PREFIX.to_vec(),
+        subtype: PSBT_OUT_TAPRET_COMMITMENT,
+        key: vec![],
+    });
+
+    match commit_vec {
+        Some(commit) => Ok(commit.to_hex()),
+        _ => Err(DbcPsbtError::TapretKey(TapretKeyError::InvalidProof)),
+    }
 }

--- a/tests/rgb_invoice.rs
+++ b/tests/rgb_invoice.rs
@@ -17,9 +17,9 @@ async fn allow_create_invoice() -> anyhow::Result<()> {
 
     let mut stock = Stock::default();
     let contract_id = generate_new_contract(&mut stock);
-    let invoice = create_invoice(&contract_id.to_string(), iface, amount, seal, &mut stock);
+    let result = create_invoice(&contract_id.to_string(), iface, amount, seal, &mut stock);
 
-    assert!(invoice.is_ok());
+    assert!(result.is_ok());
     Ok(())
 }
 
@@ -34,10 +34,12 @@ async fn allow_pay_invoice() -> anyhow::Result<()> {
     let seal = "tapret1st:ed823b41d8b9309933826b18e4af530363b359f05919c02bbe72f28cec6dec3e:0";
     let invoice = generate_new_invoice(contract_id, seal, &mut stock);
 
-    let transfer = pay_invoice(invoice.to_string(), psbt.to_string(), &mut stock);
-    assert!(transfer.is_ok());
+    let result = pay_invoice(invoice.to_string(), psbt.to_string(), &mut stock);
+    assert!(result.is_ok());
 
-    let pay_status = transfer?.unbindle().validate(&mut resolver);
+    let (_, transfer) = result.unwrap();
+
+    let pay_status = transfer.unbindle().validate(&mut resolver);
     assert!(pay_status.is_ok());
     Ok(())
 }
@@ -53,11 +55,12 @@ async fn allow_accept_invoice() -> anyhow::Result<()> {
     let seal = "tapret1st:ed823b41d8b9309933826b18e4af530363b359f05919c02bbe72f28cec6dec3e:0";
     let invoice = generate_new_invoice(contract_id, seal, &mut stock);
 
-    let transfer = pay_invoice(invoice.to_string(), psbt.to_string(), &mut stock);
-    assert!(transfer.is_ok());
+    let result = pay_invoice(invoice.to_string(), psbt.to_string(), &mut stock);
+    assert!(result.is_ok());
+
+    let (_, transfer) = result.unwrap();
 
     let transfer_hex = transfer
-        .unwrap()
         .to_strict_serialized::<0xFFFFFF>()
         .unwrap()
         .to_hex();

--- a/tests/rgb_psbt.rs
+++ b/tests/rgb_psbt.rs
@@ -47,8 +47,6 @@ async fn allow_extract_commitment() -> anyhow::Result<()> {
 
     let (psbt, _) = result.unwrap();
 
-    println!("{}", psbt.to_string());
-
     let commit = extract_commit(psbt);
     assert!(commit.is_ok());
     Ok(())


### PR DESCRIPTION
**Description**

Every TapRet-based output of a  RGB transaction has a tweak added to the taproot tree. Unfortunately, no official tooling supports spending this output later today.

This PR allow spend this output type, adding the user field to add the TapRet commitment.