### PR TITLE
Update name of wasm_bindgen method import to import_contract

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -393,7 +393,7 @@ pub mod rgb {
     }
 
     #[wasm_bindgen]
-    pub fn import(nostr_hex_sk: String, request: JsValue) -> Promise {
+    pub fn import_contract(nostr_hex_sk: String, request: JsValue) -> Promise {
         set_panic_hook();
 
         future_to_promise(async move {


### PR DESCRIPTION
The name import gives strange problems in bitmask-extension, i propose to change name to import_contract: it gives no problems and it is more descriptive