### PR TITLE
Fee and TX Improviments

### DIFF
--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -55,7 +55,7 @@ async fn invoice(
     Ok((StatusCode::OK, Json(invoice_res)))
 }
 
-async fn psbt(
+async fn _psbt(
     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
     Json(psbt_req): Json<PsbtRequest>,
 ) -> Result<impl IntoResponse, AppError> {
@@ -271,7 +271,7 @@ async fn main() -> Result<()> {
     let app = Router::new()
         .route("/issue", post(issue))
         .route("/invoice", post(invoice))
-        .route("/psbt", post(psbt))
+        // .route("/psbt", post(psbt))
         // .route("/sign", post(sign_psbt))
         .route("/pay", post(pay))
         .route("/accept", post(accept))

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -132,6 +132,8 @@ pub struct IssueResponse {
     pub precision: u8,
     /// The contract state (multiple formats)
     pub contract: ContractFormats,
+    /// The gensis state (multiple formats)
+    pub genesis: GenesisFormats,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -143,6 +145,15 @@ pub struct ContractFormats {
     pub strict: String,
     /// The contract state (compiled in armored mode)
     pub armored: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GenesisFormats {
+    /// The genesis state (encoded in bech32m)
+    pub legacy: String,
+    /// The genesis state (encoded in strict)
+    pub strict: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -185,6 +196,8 @@ pub struct ImportResponse {
     pub allocations: Vec<AllocationDetail>,
     /// The contract state (multiple formats)
     pub contract: ContractFormats,
+    /// The genesis state (multiple formats)
+    pub genesis: GenesisFormats,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -221,7 +234,7 @@ pub struct PsbtRequest {
     /// Bitcoin Change Addresses (format: {address}:{amount})
     pub bitcoin_changes: Vec<String>,
     /// Bitcoin Fee
-    pub fee: u64,
+    pub fee: Option<u64>,
     /// TapTweak used to spend outputs based in tapret commitments
     pub input_tweak: Option<String>,
 }
@@ -249,6 +262,8 @@ pub struct SignPsbtRequest {
 pub struct SignPsbtResponse {
     /// PSBT is signed?
     pub sign: bool,
+    /// Transaction encoded in Base64
+    pub tx: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/tests/rgb/integration/transfer.rs
+++ b/tests/rgb/integration/transfer.rs
@@ -209,7 +209,7 @@ async fn create_new_psbt(
         asset_utxo_terminal: asset_utxo_terminal.to_string(),
         change_index: None,
         bitcoin_changes: vec![],
-        fee: 1000,
+        fee: None,
         input_tweak: None,
     };
 


### PR DESCRIPTION
This PR intent adds some improvements based on @josediegorobles feedback. See below:

#### **Genesis Data**
Now, the methods `create_contract`, `import_contract`, and `list_contracts` return the new field called `GenesisFormats`. This field has genesis in legacy and strict formats, like `ContractFormats`.

**Important:** Even with a similar format, contracts and genesis from version 0.10 are incompatible with previous versions.

#### **Fee Calculator**

Currently, We use the create psbt method by descriptor-wallet, which does not support fee calculations. 

To solve that, I using **bdk first** to get the fee, and then I use the fee result in the wallet descriptor psbt generation. This approach has solved the fee problems by now, but I would like to return to this problem and discuss it with you guys.

**PS:** This was the solution to the extension problem not calculating the fee.

#### **SignPsbtResponse**

Now, the **psbt sign** response returns the transaction (in hexadecimal format).