### PR TITLE
Fix misnamed method and args in web.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.0-beta.6"
+version = "0.6.0-beta.7"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.0-beta.6"
+version = "0.6.0-beta.7"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/src/web.rs
+++ b/src/web.rs
@@ -141,7 +141,7 @@ pub mod bitcoin {
     }
 
     #[wasm_bindgen]
-    pub fn get_mnemonic_seed(hash: String, seed_password: String) -> Promise {
+    pub fn new_mnemonic_seed(hash: String, seed_password: String) -> Promise {
         set_panic_hook();
 
         future_to_promise(async move {
@@ -155,15 +155,11 @@ pub mod bitcoin {
     }
 
     #[wasm_bindgen]
-    pub fn save_mnemonic_seed(
-        mnemonic: String,
-        encryption_password: String,
-        hash: String,
-    ) -> Promise {
+    pub fn save_mnemonic_seed(mnemonic: String, hash: String, seed_password: String) -> Promise {
         set_panic_hook();
 
         future_to_promise(async move {
-            match crate::bitcoin::save_mnemonic_seed(&mnemonic, &encryption_password, &hash).await {
+            match crate::bitcoin::save_mnemonic_seed(&mnemonic, &hash, &seed_password).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -4,7 +4,7 @@ use bitmask_core::{
     structs::{EncryptedWalletData, MnemonicSeedData, TransactionDetails, WalletData},
     web::{
         bitcoin::{
-            get_encrypted_wallet, get_mnemonic_seed, get_wallet_data, hash_password,
+            get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed,
             save_mnemonic_seed, send_sats,
         },
         json_parse, resolve, set_panic_hook, to_string,
@@ -33,7 +33,7 @@ async fn create_wallet() {
 
     info!("Mnemonic string is 12 words long");
     let hash = hash_password(ENCRYPTION_PASSWORD.to_owned());
-    let mnemonic: JsValue = resolve(get_mnemonic_seed(hash, SEED_PASSWORD.to_owned())).await;
+    let mnemonic: JsValue = resolve(new_mnemonic_seed(hash, SEED_PASSWORD.to_owned())).await;
     assert!(!mnemonic.is_undefined());
     assert!(mnemonic.is_string());
     assert_eq!(to_string(&mnemonic).split(' ').count(), 12);


### PR DESCRIPTION
- Fix misnamed method in web.rs, get_mnemonic_seed to new_mnemonic_seed, to match the bitcoin module method it's calling.
- Fix misnamed arguments in web.rs to save_mnemonic_seed.
- Bump version to 0.6.0-beta.7

I discovered this when integrating the new extension API into bitmask-wallet.