### PR TITLE
Futureproofing Encrypted Descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.0-beta.8"
+version = "0.6.0-beta.9"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.0-beta.8"
+version = "0.6.0-beta.9"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -18,7 +18,6 @@ mod payment;
 mod psbt;
 mod wallet;
 
-use crate::structs::{EncryptedWalletDataV04, SignPsbtRequest, SignPsbtResponse};
 pub use crate::{
     bitcoin::{
         assets::dust_tx,
@@ -34,6 +33,10 @@ pub use crate::{
     },
     trace,
 };
+use crate::{
+    constants::{DIBA_DESCRIPTOR, DIBA_DESCRIPTOR_VERSION, DIBA_MAGIC_NO},
+    structs::{EncryptedWalletDataV04, SignPsbtRequest, SignPsbtResponse},
+};
 
 impl SerdeEncryptSharedKey for EncryptedWalletData {
     type S = BincodeSerializer<Self>;
@@ -45,11 +48,13 @@ impl SerdeEncryptSharedKey for EncryptedWalletDataV04 {
 
 /// Bitcoin Wallet Operations
 
-const BITMASK_ARGON2_SALT: &[u8] = b"DIBA BitMask Password Hash";
+const BITMASK_ARGON2_SALT: &[u8] = b"DIBA BitMask Password Hash"; // Never change this
 
 pub fn hash_password(password: &str) -> String {
+    use argon2::{Algorithm, Params, Version};
+
     let mut output_key_material = [0u8; 32];
-    Argon2::default()
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, Params::default())
         .hash_password_into(
             password.as_bytes(),
             BITMASK_ARGON2_SALT,
@@ -68,7 +73,22 @@ pub fn get_encrypted_wallet(
         .try_into()
         .expect("hash is of fixed size");
     let encrypted_descriptors: Vec<u8> = hex::decode(encrypted_descriptors)?;
-    let encrypted_message = EncryptedMessage::deserialize(encrypted_descriptors)?;
+    let (version_prefix, encrypted_descriptors) = encrypted_descriptors.split_at(5);
+
+    if !version_prefix.starts_with(&DIBA_MAGIC_NO) {
+        return Err(anyhow!(
+            "Wrong Format: Encrypted descriptor is not prefixed with DIBA magic number. Prefix was: {version_prefix:?}"
+        ));
+    }
+
+    if version_prefix[4] != DIBA_DESCRIPTOR_VERSION {
+        return Err(anyhow!(
+            "Wrong Version: Encrypted descriptor is the wrong version. The version byte was: {}",
+            version_prefix[4]
+        ));
+    }
+
+    let encrypted_message = EncryptedMessage::deserialize(encrypted_descriptors.to_owned())?;
 
     Ok(EncryptedWalletData::decrypt_owned(
         &encrypted_message,
@@ -119,13 +139,22 @@ pub async fn upgrade_wallet(
     }
 }
 
+pub fn versioned_descriptor(encrypted_message: EncryptedMessage) -> String {
+    let mut descriptor_data = DIBA_DESCRIPTOR.to_vec();
+    let mut encrypted_descriptors = encrypted_message.serialize();
+    descriptor_data.append(&mut encrypted_descriptors);
+
+    hex::encode(descriptor_data)
+}
+
 pub async fn new_mnemonic_seed(hash: &str, seed_password: &str) -> Result<MnemonicSeedData> {
     let shared_key: [u8; 32] = hex::decode(hash)?
         .try_into()
         .expect("hash is of fixed size");
     let wallet_data = new_mnemonic(seed_password).await?;
     let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let encrypted_descriptors = hex::encode(encrypted_message.serialize());
+    let encrypted_descriptors = versioned_descriptor(encrypted_message);
+
     let mnemonic_seed_data = MnemonicSeedData {
         mnemonic: wallet_data.mnemonic,
         encrypted_descriptors,
@@ -144,7 +173,8 @@ pub async fn save_mnemonic_seed(
         .expect("hash is of fixed size");
     let wallet_data = save_mnemonic(mnemonic_phrase, seed_password).await?;
     let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let encrypted_descriptors = hex::encode(encrypted_message.serialize());
+    let encrypted_descriptors = versioned_descriptor(encrypted_message);
+
     let mnemonic_seed_data = MnemonicSeedData {
         mnemonic: wallet_data.mnemonic,
         encrypted_descriptors,

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -18,24 +18,22 @@ mod payment;
 mod psbt;
 mod wallet;
 
-pub use crate::{
-    bitcoin::{
-        assets::dust_tx,
-        keys::{new_mnemonic, save_mnemonic},
-        payment::{create_payjoin, create_transaction},
-        psbt::sign_psbt,
-        wallet::{get_blockchain, get_wallet, synchronize_wallet},
-    },
-    debug, info,
-    structs::{
-        EncryptedWalletData, FundVaultDetails, MnemonicSeedData, SatsInvoice, WalletData,
-        WalletTransaction,
-    },
-    trace,
+pub use crate::bitcoin::{
+    assets::dust_tx,
+    keys::{new_mnemonic, save_mnemonic},
+    payment::{create_payjoin, create_transaction},
+    psbt::sign_psbt,
+    wallet::{get_blockchain, get_wallet, synchronize_wallet},
 };
+
 use crate::{
     constants::{DIBA_DESCRIPTOR, DIBA_DESCRIPTOR_VERSION, DIBA_MAGIC_NO},
-    structs::{EncryptedWalletDataV04, SignPsbtRequest, SignPsbtResponse},
+    debug, info,
+    structs::{
+        EncryptedWalletData, EncryptedWalletDataV04, FundVaultDetails, MnemonicSeedData,
+        SatsInvoice, SignPsbtRequest, SignPsbtResponse, WalletData, WalletTransaction,
+    },
+    trace,
 };
 
 impl SerdeEncryptSharedKey for EncryptedWalletData {

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -105,7 +105,7 @@ pub async fn upgrade_wallet(
             let upgraded_descriptor =
                 save_mnemonic_seed(&recovered_wallet_data.mnemonic, hash, seed_password).await?;
 
-            Some(upgraded_descriptor.serialized_encrypted_message)
+            Some(upgraded_descriptor.encrypted_descriptors)
         }
     };
 
@@ -123,12 +123,12 @@ pub async fn new_mnemonic_seed(hash: &str, seed_password: &str) -> Result<Mnemon
     let shared_key: [u8; 32] = hex::decode(hash)?
         .try_into()
         .expect("hash is of fixed size");
-    let encrypted_wallet_data = new_mnemonic(seed_password).await?;
-    let encrypted_message = encrypted_wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let serialized_encrypted_message = hex::encode(encrypted_message.serialize());
+    let wallet_data = new_mnemonic(seed_password).await?;
+    let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
+    let encrypted_descriptors = hex::encode(encrypted_message.serialize());
     let mnemonic_seed_data = MnemonicSeedData {
-        mnemonic: encrypted_wallet_data.mnemonic,
-        serialized_encrypted_message,
+        mnemonic: wallet_data.mnemonic,
+        encrypted_descriptors,
     };
 
     Ok(mnemonic_seed_data)
@@ -142,12 +142,12 @@ pub async fn save_mnemonic_seed(
     let shared_key: [u8; 32] = hex::decode(hash)?
         .try_into()
         .expect("hash is of fixed size");
-    let vault_data = save_mnemonic(mnemonic_phrase, seed_password).await?;
-    let encrypted_message = vault_data.encrypt(&SharedKey::from_array(shared_key))?;
-    let serialized_encrypted_message = hex::encode(encrypted_message.serialize());
+    let wallet_data = save_mnemonic(mnemonic_phrase, seed_password).await?;
+    let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
+    let encrypted_descriptors = hex::encode(encrypted_message.serialize());
     let mnemonic_seed_data = MnemonicSeedData {
-        mnemonic: vault_data.mnemonic,
-        serialized_encrypted_message,
+        mnemonic: wallet_data.mnemonic,
+        encrypted_descriptors,
     };
 
     Ok(mnemonic_seed_data)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,6 +59,17 @@ pub static BTC_PATH: Lazy<RwLock<String>> = Lazy::new(|| {
 // For NIP-06 Nostr signing and Carbonado encryption key derivation
 pub const NOSTR_PATH: &str = "m/44h/1237h/0h";
 
+// Magic number for versioning descriptors
+pub const DIBA_DESCRIPTOR_VERSION: u8 = 0;
+pub const DIBA_MAGIC_NO: [u8; 4] = [b'D', b'I', b'B', b'A'];
+pub const DIBA_DESCRIPTOR: [u8; 5] = [
+    DIBA_MAGIC_NO[0],
+    DIBA_MAGIC_NO[1],
+    DIBA_MAGIC_NO[2],
+    DIBA_MAGIC_NO[3],
+    DIBA_DESCRIPTOR_VERSION,
+];
+
 pub static NETWORK: Lazy<RwLock<Network>> = Lazy::new(|| {
     RwLock::new(Network::from_str(&dot_env("BITCOIN_NETWORK")).expect("Parse Bitcoin network"))
 });

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -77,7 +77,7 @@ pub struct EncryptedWalletDataV04 {
 #[serde(rename_all = "camelCase")]
 pub struct MnemonicSeedData {
     pub mnemonic: String,
-    pub serialized_encrypted_message: String,
+    pub encrypted_descriptors: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -26,7 +26,7 @@ async fn payjoin() -> Result<()> {
     let hash = hash_password(ENCRYPTION_PASSWORD);
     let mnemonic_data = save_mnemonic_seed(&mnemonic, &hash, SEED_PASSWORD).await?;
 
-    let vault = get_encrypted_wallet(&hash, &mnemonic_data.serialized_encrypted_message)?;
+    let vault = get_encrypted_wallet(&hash, &mnemonic_data.encrypted_descriptors)?;
 
     let wallet = get_wallet_data(
         &vault.private.btc_descriptor_xprv,

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -41,7 +41,7 @@ async fn create_wallet() -> Result<()> {
     let main_mnemonic = env::var("TEST_WALLET_SEED")?;
     let hash = hash_password(ENCRYPTION_PASSWORD);
     let main_mnemonic_data = save_mnemonic_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.serialized_encrypted_message)?;
+    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
     let main_rgb_wallet =
@@ -61,7 +61,7 @@ async fn get_wallet_balance() -> Result<()> {
     let main_mnemonic = env::var("TEST_WALLET_SEED")?;
     let hash = hash_password(ENCRYPTION_PASSWORD);
     let main_mnemonic_data = save_mnemonic_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.serialized_encrypted_message)?;
+    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
 

--- a/tests/web_asset.rs
+++ b/tests/web_asset.rs
@@ -50,7 +50,7 @@ async fn contract_legacy_import() {
     info!("Get vault properties");
     let vault_str: JsValue = resolve(get_encrypted_wallet(
         hash,
-        mnemonic_data.serialized_encrypted_message,
+        mnemonic_data.encrypted_descriptors,
     ))
     .await;
     let wallet_data: EncryptedWalletData = json_parse(&vault_str);
@@ -84,7 +84,7 @@ async fn contract_strict_import() {
     info!("Get vault properties");
     let vault_str: JsValue = resolve(get_encrypted_wallet(
         hash,
-        mnemonic_data.serialized_encrypted_message,
+        mnemonic_data.encrypted_descriptors,
     ))
     .await;
     let wallet_data: EncryptedWalletData = json_parse(&vault_str);
@@ -120,7 +120,7 @@ async fn asset_transfer() {
     // Get vault properties
     let wallet_data_str: JsValue = resolve(get_encrypted_wallet(
         hash,
-        mnemonic_data.serialized_encrypted_message,
+        mnemonic_data.encrypted_descriptors,
     ))
     .await;
     let wallet_data: EncryptedWalletData = json_parse(&wallet_data_str);

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -59,7 +59,7 @@ async fn import_and_open_wallet() {
     info!("Get encrypted wallet properties");
     let encrypted_wallet_str: JsValue = resolve(get_encrypted_wallet(
         hash,
-        mnemonic_data.serialized_encrypted_message,
+        mnemonic_data.encrypted_descriptors,
     ))
     .await;
     let encrypted_wallet_data: EncryptedWalletData = json_parse(&encrypted_wallet_str);
@@ -112,7 +112,7 @@ async fn import_test_wallet() {
     info!("Get vault properties");
     let vault_str: JsValue = resolve(get_encrypted_wallet(
         hash,
-        mnemonic_data.serialized_encrypted_message,
+        mnemonic_data.encrypted_descriptors,
     ))
     .await;
     let encrypted_wallet_data: EncryptedWalletData = json_parse(&vault_str);


### PR DESCRIPTION
- [x] Renames `serialized_encrypted_message` on the `MnemonicData` struct to `encrypted_descriptors`
- [x] Prefix encrypted descriptors using a magic number and version byte.
- [x] Use explicitly-defined parameters for Argon2id password hashing.