### PR TITLE
Revert rgb21 collectible support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.0-beta.15"
+version = "0.6.0-beta.16"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,14 +756,15 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "carbonado"
-version = "0.3.0-rc.8"
+version = "0.3.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83df2d8d7f54171b22b0fa2d1dd3ca0527b21615ff188a3e4edb920afc450e79"
+checksum = "2510ef3454410abef0be2d8da5b38227530a7ea55c69f666f0179410c61f8858"
 dependencies = [
  "anyhow",
  "bao",
  "bech32",
  "bitmask-enum",
+ "bytes",
  "ecies",
  "hex",
  "log",
@@ -3366,9 +3367,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.0-beta.14"
+version = "0.6.0-beta.15"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "rgb-schemata"
 version = "0.10.0-beta.1"
-source = "git+https://github.com/crisdut/rgbsc?branch=exp/full-uda#61f8f5a566fc2a6c6938026909d39e1e34f1643a"
+source = "git+https://github.com/crisdut/rgbsc?branch=exp/full-uda#8601931000b66d994e420a927807e504979e49f7"
 dependencies = [
  "aluvm",
  "amplify",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.10.2"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=exp/full-uda#e19b039e8922abd922372ead35506da718cff6de"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=exp/full-uda#4a151c049b97da5adf3e433ef7ac9362bb57e82e"
 dependencies = [
  "amplify",
  "baid58",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "rgb-wallet"
 version = "0.10.2"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=exp/full-uda#e19b039e8922abd922372ead35506da718cff6de"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=exp/full-uda#4a151c049b97da5adf3e433ef7ac9362bb57e82e"
 dependencies = [
  "amplify",
  "baid58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bp-core = "0.10.3"
 commit_verify = "0.10.2"
 bp-seals = "0.10.3"
 indexmap = "1.9.3"
-carbonado = "0.3.0-rc.8"
+carbonado = "0.3.0-rc.13"
 console_error_panic_hook = "0.1.7"
 # directories = "4.0.1"
 miniscript_crate = { package = "miniscript", version = "9.0.1", features = [
@@ -84,7 +84,7 @@ postcard = { version = "1.0.4", features = ["alloc"] }
 serde-encrypt = "0.7.0"
 strict_types = "1.2.0"
 strict_encoding = "2.2.0"
-tokio = { version = "1.28.0", features = ["macros", "sync"] }
+tokio = { version = "1.28.2", features = ["macros", "sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.0", features = [
@@ -115,7 +115,7 @@ inflate = "0.4.5"
 tower-http = { version = "0.4.0", features = ["cors"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.28.1", features = ["full"] }
+tokio = { version = "1.28.2", features = ["full"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.0-beta.15"
+version = "0.6.0-beta.16"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.0-beta.14"
+version = "0.6.0-beta.15"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -262,7 +262,7 @@ async fn co_store(
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
     let incoming_header = carbonado::file::Header::try_from(&body)?;
-    let body_len = incoming_header.encoded_len;
+    let body_len = incoming_header.encoded_len - incoming_header.padding_len;
     info!("POST /carbonado/{pk}/{name}, {body_len} bytes");
 
     let filepath = handle_file(&pk, &name, body_len.try_into()?).await?;
@@ -275,7 +275,7 @@ async fn co_store(
     {
         Ok(file) => {
             let present_header = carbonado::file::Header::try_from(&file)?;
-            let present_len = present_header.encoded_len;
+            let present_len = present_header.encoded_len - present_header.padding_len;
             debug!("body len: {body_len} present_len: {present_len}");
             if body_len > present_len {
                 debug!("body is bigger, overwriting.");

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -273,7 +273,7 @@ async fn co_store(
         }
         Err(err) => match err.kind() {
             ErrorKind::NotFound => {
-                // Do nothing
+                fs::write(&filepath, &body).await?;
             }
             _ => return Err(err.into()),
         },

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use axum::{
     body::Bytes,
     extract::Path,
-    headers::{authorization::Bearer, Authorization},
+    headers::{authorization::Bearer, Authorization, CacheControl},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -279,7 +279,9 @@ async fn co_store(
         },
     }
 
-    Ok(StatusCode::OK)
+    let cc = CacheControl::new().with_no_cache();
+
+    Ok((StatusCode::OK, TypedHeader(cc)))
 }
 
 async fn co_retrieve(
@@ -291,9 +293,11 @@ async fn co_retrieve(
 
     let bytes = fs::read(filepath).await;
 
+    let cc = CacheControl::new().with_no_cache();
+
     match bytes {
-        Ok(bytes) => Ok((StatusCode::OK, bytes)),
-        Err(_e) => Ok((StatusCode::OK, Vec::<u8>::new())),
+        Ok(bytes) => Ok((StatusCode::OK, TypedHeader(cc), bytes)),
+        Err(_e) => Ok((StatusCode::OK, TypedHeader(cc), Vec::<u8>::new())),
     }
 }
 

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -37,6 +37,7 @@ pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
         .post(&url)
         .body(body)
         .header("Content-Type", "application/octet-stream")
+        .header("Cache-Control", "no-cache")
         .send()
         .await
         .context(format!("Error sending JSON POST request to {url}"))?;
@@ -86,6 +87,7 @@ pub async fn retrieve(sk: &str, name: &str) -> Result<Vec<u8>> {
     let response = client
         .get(&url)
         .header("Accept", "application/octet-stream")
+        .header("Cache-Control", "no-cache")
         .send()
         .await
         .context(format!("Error sending JSON POST request to {url}"))?;

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -14,7 +14,10 @@ use percent_encoding::utf8_percent_encode;
 pub mod constants;
 
 #[cfg(not(feature = "server"))]
-use crate::{carbonado::constants::FORM, constants::CARBONADO_ENDPOINT};
+use crate::{
+    carbonado::constants::FORM,
+    constants::{CARBONADO_ENDPOINT, NETWORK},
+};
 
 #[cfg(not(feature = "server"))]
 pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
@@ -27,7 +30,8 @@ pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
     let (body, _encode_info) = carbonado::file::encode(&sk, Some(&pk), input, level)?;
     let endpoint = CARBONADO_ENDPOINT.read().await.to_string();
     let name = utf8_percent_encode(name, FORM);
-    let url = format!("{endpoint}/{pk_hex}/{name}");
+    let network = NETWORK.read().await.to_string();
+    let url = format!("{endpoint}/{pk_hex}/{network}-{name}");
     let client = reqwest::Client::new();
     let response = client
         .post(&url)
@@ -76,7 +80,8 @@ pub async fn retrieve(sk: &str, name: &str) -> Result<Vec<u8>> {
 
     let endpoint = CARBONADO_ENDPOINT.read().await.to_string();
     let name = utf8_percent_encode(name, FORM);
-    let url = format!("{endpoint}/{pk}/{name}");
+    let network = NETWORK.read().await.to_string();
+    let url = format!("{endpoint}/{pk}/{network}-{name}");
     let client = reqwest::Client::new();
     let response = client
         .get(&url)

--- a/src/rgb/contract.rs
+++ b/src/rgb/contract.rs
@@ -63,7 +63,7 @@ pub fn extract_contract_by_id(
 
     let mut ticker = String::new();
     let mut name = String::new();
-    let mut precision = String::new();
+    let mut precision = 0;
     let mut description = String::new();
     let mut supply = 0;
 
@@ -91,7 +91,7 @@ pub fn extract_contract_by_id(
                 if naming.contains_key(&FieldName::from("precision")) {
                     if let Some(val) = naming.get(&FieldName::from("precision")) {
                         let val = val.to_string();
-                        precision = val;
+                        precision = val.parse()?;
                     };
                 }
             }
@@ -228,7 +228,7 @@ pub fn extract_contract_by_id(
                 allocations: allocations.clone(),
             });
 
-            meta = ContractMeta::with(single);
+            meta = Some(ContractMeta::with(single));
         } else {
             let collectibles = tokens_data
                 .into_iter()
@@ -288,7 +288,9 @@ pub fn extract_contract_by_id(
                 })
                 .collect();
 
-            meta = ContractMeta::with(ContractMetadata::Collectible(collectibles));
+            meta = Some(ContractMeta::with(ContractMetadata::Collectible(
+                collectibles,
+            )));
         }
     }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -118,7 +118,7 @@ pub struct IssueRequest {
     /// The name of the iface (ex: RGB20)
     pub iface: String,
     /// contract metadata (only RGB21/UDA)
-    pub meta: IssueMetaRequest,
+    pub meta: Option<IssueMetaRequest>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -131,7 +131,7 @@ pub struct SelfIssueRequest {
     /// Description of the asset
     pub description: String,
     /// contract metadata (only RGB21/UDA)
-    pub meta: IssueMetaRequest,
+    pub meta: Option<IssueMetaRequest>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -177,6 +177,7 @@ pub struct NewCollectible {
 #[serde(rename_all = "camelCase")]
 pub struct MediaInfo {
     /// Mime Type of the media
+    #[serde(rename = "type")]
     pub ty: String,
     /// Source (aka. hyperlink) of the media
     pub source: String,
@@ -208,7 +209,7 @@ pub struct IssueResponse {
     /// The gensis state (multiple formats)
     pub genesis: GenesisFormats,
     /// contract metadata (only RGB21/UDA)
-    pub meta: ContractMeta,
+    pub meta: Option<ContractMeta>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -268,7 +269,7 @@ pub struct ContractResponse {
     /// Amount of the asset
     pub supply: u64,
     /// Precision of the asset
-    pub precision: String,
+    pub precision: u64,
     /// The user contract balance
     pub balance: u64,
     /// The contract allocations
@@ -278,7 +279,7 @@ pub struct ContractResponse {
     /// The genesis state (multiple formats)
     pub genesis: GenesisFormats,
     /// contract metadata (only RGB21/UDA)
-    pub meta: ContractMeta,
+    pub meta: Option<ContractMeta>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -15,6 +15,7 @@ use log::{debug, info};
 const ENCRYPTION_PASSWORD: &str = "hunter2";
 const SEED_PASSWORD: &str = "";
 
+#[ignore]
 #[tokio::test]
 async fn payjoin() -> Result<()> {
     init_logging("payjoin=warn");

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -9,7 +9,8 @@ mod rgb {
     }
 
     mod integration {
-        mod collectibles;
+        // TODO: Review after support multi-token transfer
+        // mod collectibles;
         mod fungibles;
         mod import;
         mod issue;

--- a/tests/rgb/integration/import.rs
+++ b/tests/rgb/integration/import.rs
@@ -6,8 +6,8 @@ use bitmask_core::{
 };
 
 use crate::rgb::integration::utils::{
-    create_new_invoice, create_new_psbt, create_new_transfer, get_collectible_data, get_uda_data,
-    import_new_contract, issuer_issue_contract, ISSUER_MNEMONIC, OWNER_MNEMONIC,
+    create_new_invoice, create_new_psbt, create_new_transfer, get_uda_data, import_new_contract,
+    issuer_issue_contract, ISSUER_MNEMONIC, OWNER_MNEMONIC,
 };
 
 #[tokio::test]
@@ -31,16 +31,16 @@ async fn allow_import_uda_contract() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn allow_import_collectible_contract() -> anyhow::Result<()> {
-    let collectibles = Some(get_collectible_data());
-    let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectibles).await;
-    assert!(issuer_resp.is_ok());
+// TODO: Review after support multi-token transfer
+// async fn _allow_import_collectible_contract() -> anyhow::Result<()> {
+//     let collectibles = Some(get_collectible_data());
+//     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectibles).await;
+//     assert!(issuer_resp.is_ok());
 
-    let import_resp = import_new_contract(issuer_resp?).await;
-    assert!(import_resp.is_ok());
-    Ok(())
-}
+//     let import_resp = import_new_contract(issuer_resp?).await;
+//     assert!(import_resp.is_ok());
+//     Ok(())
+// }
 
 #[tokio::test]
 async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
@@ -171,67 +171,67 @@ async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn allow_get_collectible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
-    // 1. Issue and Generate Trasnfer (Issuer side)
-    let collectible = Some(get_collectible_data());
-    let issuer_keys: EncryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
-    let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await?;
-    let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
-    let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
-    let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
+// TODO: Review after support multi-token transfer
+// async fn _allow_get_collectible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
+//     // 1. Issue and Generate Trasnfer (Issuer side)
+//     let collectible = Some(get_collectible_data());
+//     let issuer_keys: EncryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+//     let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
+//     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await?;
+//     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
+//     let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
+//     let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
 
-    // 2. Sign and Publish TX (Issuer side)
-    let issuer_sk = issuer_keys.private.nostr_prv.to_string();
-    let owner_sk = owner_keys.private.nostr_prv.to_string();
-    let request = SignPsbtRequest {
-        psbt: transfer_resp.clone().psbt,
-        mnemonic: ISSUER_MNEMONIC.to_string(),
-        seed_password: String::new(),
-        iface: issuer_resp.iface,
-    };
-    let resp = sign_psbt_file(&issuer_sk, request).await;
-    assert!(resp.is_ok());
+//     // 2. Sign and Publish TX (Issuer side)
+//     let issuer_sk = issuer_keys.private.nostr_prv.to_string();
+//     let owner_sk = owner_keys.private.nostr_prv.to_string();
+//     let request = SignPsbtRequest {
+//         psbt: transfer_resp.clone().psbt,
+//         mnemonic: ISSUER_MNEMONIC.to_string(),
+//         seed_password: String::new(),
+//         iface: issuer_resp.iface,
+//     };
+//     let resp = sign_psbt_file(&issuer_sk, request).await;
+//     assert!(resp.is_ok());
 
-    // 3. Accept Consig (Issuer Side)
-    let request = AcceptRequest {
-        consignment: transfer_resp.clone().consig,
-        force: false,
-    };
-    let resp = accept_transfer(&issuer_sk, request).await;
-    assert!(resp.is_ok());
-    assert!(resp?.valid);
+//     // 3. Accept Consig (Issuer Side)
+//     let request = AcceptRequest {
+//         consignment: transfer_resp.clone().consig,
+//         force: false,
+//     };
+//     let resp = accept_transfer(&issuer_sk, request).await;
+//     assert!(resp.is_ok());
+//     assert!(resp?.valid);
 
-    // 4. Accept Consig (Owner Side)
-    let request = AcceptRequest {
-        consignment: transfer_resp.consig,
-        force: false,
-    };
-    let resp = accept_transfer(&owner_sk, request).await;
-    assert!(resp.is_ok());
-    assert!(resp?.valid);
+//     // 4. Accept Consig (Owner Side)
+//     let request = AcceptRequest {
+//         consignment: transfer_resp.consig,
+//         force: false,
+//     };
+//     let resp = accept_transfer(&owner_sk, request).await;
+//     assert!(resp.is_ok());
+//     assert!(resp?.valid);
 
-    // 5. Retrieve Contract (Issuer Side)
-    let contract_id = &issuer_resp.contract_id;
-    let resp = get_contract(&issuer_sk, contract_id).await;
-    assert!(resp.is_ok());
-    assert_eq!(0, resp?.balance);
+//     // 5. Retrieve Contract (Issuer Side)
+//     let contract_id = &issuer_resp.contract_id;
+//     let resp = get_contract(&issuer_sk, contract_id).await;
+//     assert!(resp.is_ok());
+//     assert_eq!(0, resp?.balance);
 
-    // 6. Create Watcher (Owner Side)
-    let watcher_name = "default";
-    let create_watch_req = WatcherRequest {
-        name: watcher_name.to_string(),
-        xpub: owner_keys.public.watcher_xpub,
-        force: true,
-    };
-    create_watcher(&owner_sk, create_watch_req).await?;
+//     // 6. Create Watcher (Owner Side)
+//     let watcher_name = "default";
+//     let create_watch_req = WatcherRequest {
+//         name: watcher_name.to_string(),
+//         xpub: owner_keys.public.watcher_xpub,
+//         force: true,
+//     };
+//     create_watcher(&owner_sk, create_watch_req).await?;
 
-    // 7. Retrieve Contract (Owner Side)
-    let contract_id = &issuer_resp.contract_id;
-    let resp = get_contract(&owner_sk, contract_id).await;
-    assert!(resp.is_ok());
-    assert_eq!(1, resp?.balance);
+//     // 7. Retrieve Contract (Owner Side)
+//     let contract_id = &issuer_resp.contract_id;
+//     let resp = get_contract(&owner_sk, contract_id).await;
+//     assert!(resp.is_ok());
+//     assert_eq!(1, resp?.balance);
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/tests/rgb/integration/issue.rs
+++ b/tests/rgb/integration/issue.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-use crate::rgb::integration::utils::{get_collectible_data, get_uda_data, issuer_issue_contract};
+use crate::rgb::integration::utils::{get_uda_data, issuer_issue_contract};
 
 #[tokio::test]
 async fn allow_issuer_issue_fungible_contract() -> anyhow::Result<()> {
@@ -16,10 +16,10 @@ async fn allow_issuer_issue_uda_contract() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn allow_issuer_issue_collectible_contract() -> anyhow::Result<()> {
-    let collectible = Some(get_collectible_data());
-    let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await;
-    assert!(issuer_resp.is_ok());
-    Ok(())
-}
+// TODO: Review after support multi-token transfer
+// async fn _allow_issuer_issue_collectible_contract() -> anyhow::Result<()> {
+//     let collectible = Some(get_collectible_data());
+//     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await;
+//     assert!(issuer_resp.is_ok());
+//     Ok(())
+// }

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -153,11 +153,6 @@ pub async fn issuer_issue_contract(
         next_utxo = watcher_next_utxo(&sk, watcher_name, iface).await?;
     }
 
-    let meta = match meta {
-        Some(meta) => meta,
-        _ => IssueMetaRequest::default(),
-    };
-
     let issue_utxo = next_utxo.utxo;
     let issue_seal = format!("tapret1st:{issue_utxo}");
     let request = IssueRequest {
@@ -337,7 +332,7 @@ pub fn get_uda_data() -> IssueMetaRequest {
     }]))
 }
 
-pub fn get_collectible_data() -> IssueMetaRequest {
+pub fn _get_collectible_data() -> IssueMetaRequest {
     IssueMetaRequest::with(IssueMetadata::Collectible(vec![
         NewCollectible {
             ticker: "DIBAA".to_string(),

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -283,7 +283,7 @@ pub async fn create_new_psbt(
 
         if let Some(allocation) = allocations.into_iter().next() {
             asset_utxo = allocation.utxo.to_owned();
-            asset_utxo_terminal = allocation.derivation.to_owned();
+            asset_utxo_terminal = allocation.derivation;
             break;
         }
     }

--- a/tests/rgb/unit/issue.rs
+++ b/tests/rgb/unit/issue.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 use anyhow::Result;
-use bitmask_core::{rgb::issue::issue_contract, structs::IssueMetaRequest, util::init_logging};
+use bitmask_core::{rgb::issue::issue_contract, util::init_logging};
 use rgbstd::persistence::Stock;
 
 use crate::rgb::unit::utils::DumbResolve;
@@ -31,7 +31,7 @@ async fn issue_contract_test() -> Result<()> {
         iface,
         seal,
         network,
-        IssueMetaRequest::default(),
+        None,
         &mut resolver,
         &mut stock,
     );

--- a/tests/rgb/unit/utils.rs
+++ b/tests/rgb/unit/utils.rs
@@ -2,9 +2,7 @@ use std::{collections::HashMap, convert::Infallible, str::FromStr};
 
 use amplify::hex::{FromHex, ToHex};
 use bitcoin::Transaction;
-use bitmask_core::{
-    rgb::issue::issue_contract, rgb::transfer::create_invoice, structs::IssueMetaRequest,
-};
+use bitmask_core::{rgb::issue::issue_contract, rgb::transfer::create_invoice};
 use bp::{
     LockTime, Outpoint, Sats, ScriptPubkey, SeqNo, Tx, TxIn, TxOut, TxVer, Txid, VarIntArray,
     Witness,
@@ -102,7 +100,7 @@ pub fn create_fake_contract(stock: &mut Stock) -> ContractId {
         iface,
         seal,
         network,
-        IssueMetaRequest::default(),
+        None,
         &mut resolver,
         stock,
     )


### PR DESCRIPTION
According Maxim, multi-tokens per contract need some improvements in AluVM.

This PR intent revert the changes made in RGB21 contract and minor improvements in Structs.

PS: I kept the meta enum the way it was, but don't use the Collectible, only UDA variant.

Depends  https://github.com/diba-io/bitmask-extension/pull/291