### PR TITLE
bitmaskd fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.0-beta.15"
+version = "0.6.0-beta.16"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,14 +756,15 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "carbonado"
-version = "0.3.0-rc.8"
+version = "0.3.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83df2d8d7f54171b22b0fa2d1dd3ca0527b21615ff188a3e4edb920afc450e79"
+checksum = "2510ef3454410abef0be2d8da5b38227530a7ea55c69f666f0179410c61f8858"
 dependencies = [
  "anyhow",
  "bao",
  "bech32",
  "bitmask-enum",
+ "bytes",
  "ecies",
  "hex",
  "log",
@@ -3366,9 +3367,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bp-core = "0.10.3"
 commit_verify = "0.10.2"
 bp-seals = "0.10.3"
 indexmap = "1.9.3"
-carbonado = "0.3.0-rc.8"
+carbonado = "0.3.0-rc.13"
 console_error_panic_hook = "0.1.7"
 # directories = "4.0.1"
 miniscript_crate = { package = "miniscript", version = "9.0.1", features = [
@@ -84,7 +84,7 @@ postcard = { version = "1.0.4", features = ["alloc"] }
 serde-encrypt = "0.7.0"
 strict_types = "1.2.0"
 strict_encoding = "2.2.0"
-tokio = { version = "1.28.0", features = ["macros", "sync"] }
+tokio = { version = "1.28.2", features = ["macros", "sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.0", features = [
@@ -115,7 +115,7 @@ inflate = "0.4.5"
 tower-http = { version = "0.4.0", features = ["cors"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.28.1", features = ["full"] }
+tokio = { version = "1.28.2", features = ["full"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.0-beta.15"
+version = "0.6.0-beta.16"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -262,7 +262,7 @@ async fn co_store(
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
     let incoming_header = carbonado::file::Header::try_from(&body)?;
-    let body_len = incoming_header.encoded_len;
+    let body_len = incoming_header.encoded_len - incoming_header.padding_len;
     info!("POST /carbonado/{pk}/{name}, {body_len} bytes");
 
     let filepath = handle_file(&pk, &name, body_len.try_into()?).await?;
@@ -275,7 +275,7 @@ async fn co_store(
     {
         Ok(file) => {
             let present_header = carbonado::file::Header::try_from(&file)?;
-            let present_len = present_header.encoded_len;
+            let present_len = present_header.encoded_len - present_header.padding_len;
             debug!("body len: {body_len} present_len: {present_len}");
             if body_len > present_len {
                 debug!("body is bigger, overwriting.");

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -273,7 +273,7 @@ async fn co_store(
         }
         Err(err) => match err.kind() {
             ErrorKind::NotFound => {
-                // Do nothing
+                fs::write(&filepath, &body).await?;
             }
             _ => return Err(err.into()),
         },

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use axum::{
     body::Bytes,
     extract::Path,
-    headers::{authorization::Bearer, Authorization},
+    headers::{authorization::Bearer, Authorization, CacheControl},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -279,7 +279,9 @@ async fn co_store(
         },
     }
 
-    Ok(StatusCode::OK)
+    let cc = CacheControl::new().with_no_cache();
+
+    Ok((StatusCode::OK, TypedHeader(cc)))
 }
 
 async fn co_retrieve(
@@ -291,9 +293,11 @@ async fn co_retrieve(
 
     let bytes = fs::read(filepath).await;
 
+    let cc = CacheControl::new().with_no_cache();
+
     match bytes {
-        Ok(bytes) => Ok((StatusCode::OK, bytes)),
-        Err(_e) => Ok((StatusCode::OK, Vec::<u8>::new())),
+        Ok(bytes) => Ok((StatusCode::OK, TypedHeader(cc), bytes)),
+        Err(_e) => Ok((StatusCode::OK, TypedHeader(cc), Vec::<u8>::new())),
     }
 }
 

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -37,6 +37,7 @@ pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
         .post(&url)
         .body(body)
         .header("Content-Type", "application/octet-stream")
+        .header("Cache-Control", "no-cache")
         .send()
         .await
         .context(format!("Error sending JSON POST request to {url}"))?;
@@ -86,6 +87,7 @@ pub async fn retrieve(sk: &str, name: &str) -> Result<Vec<u8>> {
     let response = client
         .get(&url)
         .header("Accept", "application/octet-stream")
+        .header("Cache-Control", "no-cache")
         .send()
         .await
         .context(format!("Error sending JSON POST request to {url}"))?;

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -14,7 +14,10 @@ use percent_encoding::utf8_percent_encode;
 pub mod constants;
 
 #[cfg(not(feature = "server"))]
-use crate::{carbonado::constants::FORM, constants::CARBONADO_ENDPOINT};
+use crate::{
+    carbonado::constants::FORM,
+    constants::{CARBONADO_ENDPOINT, NETWORK},
+};
 
 #[cfg(not(feature = "server"))]
 pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
@@ -27,7 +30,8 @@ pub async fn store(sk: &str, name: &str, input: &[u8]) -> Result<()> {
     let (body, _encode_info) = carbonado::file::encode(&sk, Some(&pk), input, level)?;
     let endpoint = CARBONADO_ENDPOINT.read().await.to_string();
     let name = utf8_percent_encode(name, FORM);
-    let url = format!("{endpoint}/{pk_hex}/{name}");
+    let network = NETWORK.read().await.to_string();
+    let url = format!("{endpoint}/{pk_hex}/{network}-{name}");
     let client = reqwest::Client::new();
     let response = client
         .post(&url)
@@ -76,7 +80,8 @@ pub async fn retrieve(sk: &str, name: &str) -> Result<Vec<u8>> {
 
     let endpoint = CARBONADO_ENDPOINT.read().await.to_string();
     let name = utf8_percent_encode(name, FORM);
-    let url = format!("{endpoint}/{pk}/{name}");
+    let network = NETWORK.read().await.to_string();
+    let url = format!("{endpoint}/{pk}/{network}-{name}");
     let client = reqwest::Client::new();
     let response = client
         .get(&url)

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -283,7 +283,7 @@ pub async fn create_new_psbt(
 
         if let Some(allocation) = allocations.into_iter().next() {
             asset_utxo = allocation.utxo.to_owned();
-            asset_utxo_terminal = allocation.derivation.to_owned();
+            asset_utxo_terminal = allocation.derivation;
             break;
         }
     }


### PR DESCRIPTION
- [x] Prefix files with the network BMC is currently set to
- [x] Only overwrites a file if it does not exist or if it what's being written is larger
- [x] Parses actual Carbonado headers for file size, not just bytes len.
- [x] Supply no-cache Content-Control headers on both request and response
