### PR TITLE
Docker build for Apple M1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 wasm-pack.log
 launch.json
+/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: "3.7"
 networks:
   bmnet:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.21.0.0/24
-          gateway: 172.21.0.1
+    # ipam:
+    #   config:
+    #     - subnet: 172.21.0.0/24
+    #       gateway: 172.21.0.1
 
 volumes:
   node1_data:
@@ -28,7 +28,7 @@ services:
       - 3000:80
     networks:
       bmnet:
-        ipv4_address: 172.21.0.4
+        # ipv4_address: 172.21.0.4
         aliases:
           - node1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   node1:
     container_name: bitcoin1
     image: bitmask/node1:latest
+    platform: linux/amd64
     build:
       context: ./docker/esplora/
     restart: unless-stopped
@@ -34,6 +35,7 @@ services:
   bitmaskd:
     container_name: bitmaskd
     image: bitmask/server:latest
+    platform: linux/amd64
     build:
       context: ./
       dockerfile: ./docker/bitmask/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       context: ./
       dockerfile: ./docker/bitmask/Dockerfile
     restart: unless-stopped
+    environment:
+      - BITCOIN_NETWORK=regtest
+      - BITCOIN_EXPLORER_API_REGTEST=http://node1:80/regtest/api
     ports:
       - 7070:7070
     networks:

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -4,14 +4,13 @@ ARG BUILDER_DIR=/srv/bitmask
 ARG BUILDER_SRC=/opt/src/bitmask
 
 RUN apt-get update -y && \
-  apt-get install -y pkg-config make g++ libssl-dev && \
-  rustup target add x86_64-unknown-linux-gnu
+  apt-get install -y pkg-config make g++ libssl-dev
 
 WORKDIR $BUILDER_DIR
 WORKDIR $BUILDER_SRC
 COPY . .
 
-RUN cargo install --locked --all-features --path . --root ${BUILDER_DIR} --target x86_64-unknown-linux-gnu
+RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
 # Runtime
 FROM rust:slim AS runtime
@@ -21,7 +20,7 @@ ARG BIN_DIR=/usr/local/bin
 ARG DATA_DIR=/tmp/bitmaskd/carbonado/
 ARG USER=bitmask
 
-RUN apt-get update -y \
+RUN apt-get update -y && apt-get install -y iputils-ping telnet \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN adduser --home "${DATA_DIR}" --shell /bin/bash --disabled-login \


### PR DESCRIPTION
@trevor-ofarrell help me a noticed the strange behavior in Apple M1 + Docker.  For some reason, bitmaskd cannot connect to dockernized bitcoin node1.

My suspect it error occurs because Docker build image with **linux/amd64/v8** instead of **linux/amd64(/v7)** in Apple M1 with MacOS 12.x or above.

- Instructions to Apple M1 [here](https://levelup.gitconnected.com/docker-on-apple-silicon-mac-how-to-run-x86-containers-with-rosetta-2-4a679913a0d5). **Warrning:** I tested in old version of MacOS (11.x) and this freeze docker and I needed reinstall docker. This instructions works only 12.x or above.
- Other good article [about it](https://earthly.dev/blog/using-apple-silicon-m1-as-a-cloud-engineer-two-months-in/)

@trevor-ofarrell, 
Could you review and test, please?

Thanks