### PR TITLE
Add no-cache cache control header to carbonado status endpoint.

### DIFF
--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -327,7 +327,9 @@ async fn co_retrieve(
 }
 
 async fn status() -> Result<impl IntoResponse, AppError> {
-    Ok((StatusCode::OK, "OK".to_string()))
+    let cc = CacheControl::new().with_no_cache();
+
+    Ok((StatusCode::OK, TypedHeader(cc), "OK".to_string()))
 }
 
 async fn key(Path(pk): Path<String>) -> Result<impl IntoResponse, AppError> {


### PR DESCRIPTION
Let's also add this, in case it helps.