### PR TITLE
Better Entropy and Secrets Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.7",
 ]
 
 [[package]]
@@ -611,6 +611,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "zeroize",
 ]
 
 [[package]]
@@ -799,21 +800,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
  "cfg-if",
  "cipher 0.3.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
  "aead 0.4.3",
  "chacha20",
@@ -924,6 +925,15 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
@@ -975,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a41c3b5488899ea68ee2dd99e089b95629c6407150bda8e56f2602d78fec8e4"
+checksum = "1efe589deb705b2dcc2b6ad84162d355b819d1205b8d8498c0d149e36b329c30"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -999,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -2312,7 +2322,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "opaque-debug",
  "universal-hash 0.4.1",
 ]
@@ -2324,7 +2334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "opaque-debug",
  "universal-hash 0.5.0",
 ]
@@ -2737,9 +2747,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "1c7c5f10864beba947e1a1b43f3ef46c8cc58d1c2ae549fa471713e8ff60787a"
 dependencies = [
  "cipher 0.3.0",
  "zeroize",
@@ -3046,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "digest 0.10.6",
 ]
 
@@ -3058,7 +3068,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -3070,7 +3080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "digest 0.10.6",
 ]
 
@@ -4090,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -4101,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0f69b133860e3614a4d4fdd6f0d7fe3219e9d67a7e8cd537676a4ebc8313db"
+checksum = "a214b4d445e6534a858c970b44eb526c398dbfaa2961e3efb637307af634284d"
 dependencies = [
  "aead 0.4.3",
  "poly1305",
@@ -4115,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "descriptor-wallet",
  "esplora-client 0.5.0",
  "futures",
+ "getrandom",
  "gloo-console",
  "gloo-net",
  "hex",
@@ -1383,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ descriptor-wallet = { version = "0.10.0-alpha.2", features = [
 futures = { version = "0.3.28", features = [
     "executor",
 ], default-features = true }
-getrandom = "0.2.10"
+getrandom = { version = "0.2.10", features = ["js"] }
 hex = "0.4.3"
 lightning-invoice = "0.23.0"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ argon2 = "0.5.0"
 base64 = { package = "base64-compat", version = "1.0.0" }
 bech32 = "0.9.1"
 bip39 = { version = "2.0.0", features = ["rand"] }
+zeroize = "1.6.0"
 bitcoin_30 = { package = "bitcoin", version = "0.30", features = ["base64"] }
 bitcoin = { version = "0.29.2", features = ["base64"] }
 bitcoin_hashes = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ descriptor-wallet = { version = "0.10.0-alpha.2", features = [
 futures = { version = "0.3.28", features = [
     "executor",
 ], default-features = true }
+getrandom = "0.2.10"
 hex = "0.4.3"
 lightning-invoice = "0.23.0"
 log = "0.4.17"

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -47,7 +47,11 @@ async fn issue(Json(issue): Json<IssueAssetRequest>) -> Result<impl IntoResponse
 
 async fn self_issue(Json(issue): Json<SelfIssueRequest>) -> Result<impl IntoResponse, AppError> {
     info!("POST /self_issue {issue:?}");
-    let issuer_keys = save_mnemonic(&SecretString(get_marketplace_seed().await), "").await?;
+    let issuer_keys = save_mnemonic(
+        &SecretString(get_marketplace_seed().await),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     let issue_seal = format!("tapret1st:{}", get_udas_utxo().await);
     let request = IssueRequest {
@@ -93,13 +97,11 @@ async fn _psbt(
 }
 
 async fn _sign_psbt(
-    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    TypedHeader(_auth): TypedHeader<Authorization<Bearer>>,
     Json(psbt_req): Json<SignPsbtRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     info!("POST /sign {psbt_req:?}");
-
-    let nostr_hex_sk = auth.token();
-    let psbt_res = sign_psbt_file(nostr_hex_sk, psbt_req).await?;
+    let psbt_res = sign_psbt_file(psbt_req).await?;
 
     Ok((StatusCode::OK, Json(psbt_res)))
 }

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -11,6 +11,7 @@ use serde_encrypt::{
     AsSharedKey, EncryptedMessage,
 };
 use tokio::try_join;
+use zeroize::Zeroize;
 
 mod assets;
 mod keys;
@@ -30,13 +31,13 @@ use crate::{
     constants::{DIBA_DESCRIPTOR, DIBA_DESCRIPTOR_VERSION, DIBA_MAGIC_NO},
     debug, info,
     structs::{
-        EncryptedWalletData, EncryptedWalletDataV04, FundVaultDetails, MnemonicSeedData,
-        SatsInvoice, SignPsbtRequest, SignPsbtResponse, WalletData, WalletTransaction,
+        DecryptedWalletData, EncryptedWalletDataV04, FundVaultDetails, SatsInvoice, SecretString,
+        SignPsbtRequest, SignPsbtResponse, WalletData, WalletTransaction,
     },
     trace,
 };
 
-impl SerdeEncryptSharedKey for EncryptedWalletData {
+impl SerdeEncryptSharedKey for DecryptedWalletData {
     type S = BincodeSerializer<Self>;
 }
 
@@ -48,29 +49,33 @@ impl SerdeEncryptSharedKey for EncryptedWalletDataV04 {
 
 const BITMASK_ARGON2_SALT: &[u8] = b"DIBA BitMask Password Hash"; // Never change this
 
-pub fn hash_password(password: &str) -> String {
+pub fn hash_password(password: &SecretString) -> SecretString {
     use argon2::{Algorithm, Params, Version};
 
     let mut output_key_material = [0u8; 32];
     Argon2::new(Algorithm::Argon2id, Version::V0x13, Params::default())
         .hash_password_into(
-            password.as_bytes(),
+            password.0.as_bytes(),
             BITMASK_ARGON2_SALT,
             &mut output_key_material,
         )
         .expect("Password hashed with Argon2id");
 
-    hex::encode(output_key_material)
+    output_key_material.zeroize();
+
+    SecretString(hex::encode(output_key_material))
 }
 
-pub fn get_encrypted_wallet(
-    hash: &str,
-    encrypted_descriptors: &str,
-) -> Result<EncryptedWalletData> {
-    let shared_key: [u8; 32] = hex::decode(hash)?
+pub fn decrypt_wallet(
+    hash: &SecretString,
+    encrypted_descriptors: &SecretString,
+) -> Result<DecryptedWalletData> {
+    // let hash: &str = hash.0.as_ref();
+    let mut shared_key: [u8; 32] = hex::decode(&hash.0)?
         .try_into()
         .expect("hash is of fixed size");
-    let encrypted_descriptors: Vec<u8> = hex::decode(encrypted_descriptors)?;
+    // let encrypted_descriptors: &str = encrypted_descriptors.0.as_ref();
+    let encrypted_descriptors: Vec<u8> = hex::decode(&encrypted_descriptors.0)?;
     let (version_prefix, encrypted_descriptors) = encrypted_descriptors.split_at(5);
 
     if !version_prefix.starts_with(&DIBA_MAGIC_NO) {
@@ -88,29 +93,29 @@ pub fn get_encrypted_wallet(
 
     let encrypted_message = EncryptedMessage::deserialize(encrypted_descriptors.to_owned())?;
 
-    Ok(EncryptedWalletData::decrypt_owned(
-        &encrypted_message,
-        &SharedKey::from_array(shared_key),
-    )?)
+    let decrypted_wallet_data =
+        DecryptedWalletData::decrypt_owned(&encrypted_message, &SharedKey::from_array(shared_key))?;
+
+    shared_key.zeroize();
+
+    Ok(decrypted_wallet_data)
 }
 
 pub async fn upgrade_wallet(
-    hash: &str,
-    encrypted_descriptors: &str,
-    seed_password: &str,
-) -> Result<String> {
+    hash: &SecretString,
+    encrypted_descriptors: &SecretString,
+    seed_password: &SecretString,
+) -> Result<SecretString> {
     // read hash digest and consume hasher
-    let shared_key: [u8; 32] = hex::decode(hash)?
+    let shared_key: [u8; 32] = hex::decode(&hash.0)?
         .try_into()
         .expect("hash is of fixed size");
-    let encrypted_descriptors: Vec<u8> = hex::decode(encrypted_descriptors)?;
+    let encrypted_descriptors: Vec<u8> = hex::decode(&encrypted_descriptors.0)?;
     let encrypted_message = EncryptedMessage::deserialize(encrypted_descriptors)?;
 
-    let descriptor = match EncryptedWalletData::decrypt_owned(
-        &encrypted_message,
-        &SharedKey::from_array(shared_key),
-    ) {
-        Ok(_data) => None,
+    match DecryptedWalletData::decrypt_owned(&encrypted_message, &SharedKey::from_array(shared_key))
+    {
+        Ok(_data) => Err(anyhow!("Descriptor does not need to be upgraded")),
         Err(_err) => {
             // If there's a deserialization error, attempt to recover just the mnemnonic.
             let recovered_wallet_data = EncryptedWalletDataV04::decrypt_owned(
@@ -119,21 +124,17 @@ pub async fn upgrade_wallet(
             )?;
 
             // println!("Recovered wallet data: {recovered_wallet_data:?}"); // Keep commented out for security
+            // todo!("Add later version migrations here");
 
-            let upgraded_descriptor =
-                save_mnemonic_seed(&recovered_wallet_data.mnemonic, hash, seed_password).await?;
+            let upgraded_descriptor = encrypt_seed(
+                &SecretString(recovered_wallet_data.mnemonic),
+                hash,
+                seed_password,
+            )
+            .await?;
 
-            Some(upgraded_descriptor.encrypted_descriptors)
+            Ok(upgraded_descriptor)
         }
-    };
-
-    // if descriptor.is_none() {
-    //     todo!("Add later version migrations here");
-    // }
-
-    match descriptor {
-        Some(result) => Ok(result),
-        None => Err(anyhow!("Descriptor does not need to be upgraded")),
     }
 }
 
@@ -145,40 +146,30 @@ pub fn versioned_descriptor(encrypted_message: EncryptedMessage) -> String {
     hex::encode(descriptor_data)
 }
 
-pub async fn new_mnemonic_seed(hash: &str, seed_password: &str) -> Result<MnemonicSeedData> {
-    let shared_key: [u8; 32] = hex::decode(hash)?
+pub async fn new_wallet(hash: &SecretString, seed_password: &SecretString) -> Result<String> {
+    let shared_key: [u8; 32] = hex::decode(&hash.0)?
         .try_into()
         .expect("hash is of fixed size");
     let wallet_data = new_mnemonic(seed_password).await?;
     let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
     let encrypted_descriptors = versioned_descriptor(encrypted_message);
 
-    let mnemonic_seed_data = MnemonicSeedData {
-        mnemonic: wallet_data.mnemonic,
-        encrypted_descriptors,
-    };
-
-    Ok(mnemonic_seed_data)
+    Ok(encrypted_descriptors)
 }
 
-pub async fn save_mnemonic_seed(
-    mnemonic_phrase: &str,
-    hash: &str,
-    seed_password: &str,
-) -> Result<MnemonicSeedData> {
-    let shared_key: [u8; 32] = hex::decode(hash)?
+pub async fn encrypt_seed(
+    mnemonic_phrase: &SecretString,
+    hash: &SecretString,
+    seed_password: &SecretString,
+) -> Result<SecretString> {
+    let shared_key: [u8; 32] = hex::decode(&hash.0)?
         .try_into()
         .expect("hash is of fixed size");
     let wallet_data = save_mnemonic(mnemonic_phrase, seed_password).await?;
     let encrypted_message = wallet_data.encrypt(&SharedKey::from_array(shared_key))?;
     let encrypted_descriptors = versioned_descriptor(encrypted_message);
 
-    let mnemonic_seed_data = MnemonicSeedData {
-        mnemonic: wallet_data.mnemonic,
-        encrypted_descriptors,
-    };
-
-    Ok(mnemonic_seed_data)
+    Ok(SecretString(encrypted_descriptors))
 }
 
 pub async fn get_wallet_data(
@@ -423,14 +414,15 @@ pub async fn sign_psbt_file(_sk: &str, request: SignPsbtRequest) -> Result<SignP
     let final_psbt = PartiallySignedTransaction::from(original_psbt);
 
     // TODO: Refactor this!
-    let encrypt_wallet = save_mnemonic(&mnemonic, &seed_password).await?;
+    let encrypt_wallet =
+        save_mnemonic(&SecretString(mnemonic), &SecretString(seed_password)).await?;
     let sk = match iface.as_str() {
-        "RGB20" => encrypt_wallet.private.rgb_assets_descriptor_xprv,
-        "RGB21" => encrypt_wallet.private.rgb_udas_descriptor_xprv,
-        _ => encrypt_wallet.private.rgb_assets_descriptor_xprv,
+        "RGB20" => &encrypt_wallet.private.rgb_assets_descriptor_xprv,
+        "RGB21" => &encrypt_wallet.private.rgb_udas_descriptor_xprv,
+        _ => &encrypt_wallet.private.rgb_assets_descriptor_xprv,
     };
 
-    let wallet = get_wallet(&sk, None).await?;
+    let wallet = get_wallet(sk, None).await?;
     synchronize_wallet(&wallet).await?;
 
     let sign = sign_psbt(&wallet, final_psbt).await?;

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -178,7 +178,7 @@ pub async fn encrypt_wallet(
 
 pub async fn get_wallet_data(
     descriptor: &SecretString,
-    change_descriptor: Option<&SecretString>,
+    change_descriptor: Option<SecretString>,
 ) -> Result<WalletData> {
     info!("get_wallet_data");
 
@@ -235,7 +235,7 @@ pub async fn get_wallet_data(
 
 pub async fn get_new_address(
     descriptor: &SecretString,
-    change_descriptor: Option<&SecretString>,
+    change_descriptor: Option<SecretString>,
 ) -> Result<String> {
     info!("get_new_address");
 
@@ -259,7 +259,7 @@ pub async fn send_sats(
 ) -> Result<TransactionDetails> {
     use payjoin::UriExt;
 
-    let wallet = get_wallet(descriptor, Some(change_descriptor)).await?;
+    let wallet = get_wallet(descriptor, Some(change_descriptor.to_owned())).await?;
     synchronize_wallet(&wallet).await?;
 
     let fee_rate = fee_rate.map(FeeRate::from_sat_per_vb);
@@ -300,7 +300,11 @@ pub async fn fund_vault(
     let assets_address = Address::from_str(assets_address)?;
     let uda_address = Address::from_str(uda_address)?;
 
-    let wallet = get_wallet(btc_descriptor_xprv, Some(btc_change_descriptor_xprv)).await?;
+    let wallet = get_wallet(
+        btc_descriptor_xprv,
+        Some(btc_change_descriptor_xprv.clone()),
+    )
+    .await?;
     synchronize_wallet(&wallet).await?;
 
     let asset_invoice = SatsInvoice {

--- a/src/bitcoin/keys.rs
+++ b/src/bitcoin/keys.rs
@@ -83,7 +83,7 @@ fn nostr_keypair(xprv: &ExtendedPrivKey, path: &str, change: u32) -> Result<(Str
 }
 
 pub async fn new_mnemonic(seed_password: &SecretString) -> Result<DecryptedWalletData> {
-    let mut entropy: Vec<u8> = Vec::with_capacity(32);
+    let mut entropy = [0u8; 32];
     getrandom::getrandom(&mut entropy)?;
     let mnemonic = Mnemonic::from_entropy_in(Language::English, &entropy)?;
     entropy.zeroize();

--- a/src/bitcoin/keys.rs
+++ b/src/bitcoin/keys.rs
@@ -84,7 +84,7 @@ fn nostr_keypair(xprv: &ExtendedPrivKey, path: &str, change: u32) -> Result<(Str
 
 pub async fn new_mnemonic(seed_password: &SecretString) -> Result<DecryptedWalletData> {
     let mut entropy: Vec<u8> = Vec::with_capacity(32);
-    todo!("WebCrypto");
+    getrandom::getrandom(&mut entropy)?;
     let mnemonic = Mnemonic::from_entropy_in(Language::English, &entropy)?;
     entropy.zeroize();
 

--- a/src/bitcoin/keys.rs
+++ b/src/bitcoin/keys.rs
@@ -13,10 +13,11 @@ use bip39::{Language, Mnemonic};
 use bitcoin_hashes::{sha256, Hash};
 use miniscript_crate::DescriptorPublicKey;
 use nostr_sdk::prelude::{FromSkStr, ToBech32};
+use zeroize::Zeroize;
 
 use crate::{
     constants::{BTC_PATH, NETWORK, NOSTR_PATH},
-    structs::{EncryptedWalletData, PrivateWalletData, PublicWalletData},
+    structs::{DecryptedWalletData, PrivateWalletData, PublicWalletData, SecretString},
 };
 
 fn get_descriptor(xprv: &ExtendedPrivKey, path: &str, change: u32) -> Result<DescriptorSecretKey> {
@@ -81,27 +82,29 @@ fn nostr_keypair(xprv: &ExtendedPrivKey, path: &str, change: u32) -> Result<(Str
     }
 }
 
-pub async fn new_mnemonic(seed_password: &str) -> Result<EncryptedWalletData> {
-    let mut rng = bip39::rand::thread_rng();
-    let mnemonic_phrase = Mnemonic::generate_in_with(&mut rng, Language::English, 12)?;
+pub async fn new_mnemonic(seed_password: &SecretString) -> Result<DecryptedWalletData> {
+    let mut entropy: Vec<u8> = Vec::with_capacity(32);
+    todo!("WebCrypto");
+    let mnemonic = Mnemonic::from_entropy_in(Language::English, &entropy)?;
+    entropy.zeroize();
 
-    get_mnemonic(mnemonic_phrase, seed_password).await
+    get_mnemonic(mnemonic, seed_password).await
 }
 
 pub async fn save_mnemonic(
-    mnemonic_phrase: &str,
-    seed_password: &str,
-) -> Result<EncryptedWalletData> {
-    let mnemonic = Mnemonic::from_str(mnemonic_phrase)?;
+    mnemonic_phrase: &SecretString,
+    seed_password: &SecretString,
+) -> Result<DecryptedWalletData> {
+    let mnemonic = Mnemonic::from_str(&mnemonic_phrase.0)?;
 
     get_mnemonic(mnemonic, seed_password).await
 }
 
 pub async fn get_mnemonic(
     mnemonic_phrase: Mnemonic,
-    seed_password: &str,
-) -> Result<EncryptedWalletData> {
-    let seed = mnemonic_phrase.to_seed_normalized(seed_password);
+    seed_password: &SecretString,
+) -> Result<DecryptedWalletData> {
+    let seed = mnemonic_phrase.to_seed_normalized(&seed_password.0);
 
     let network = NETWORK.read().await;
     let xprv = ExtendedPrivKey::new_master(*network, &seed)?;
@@ -151,7 +154,7 @@ pub async fn get_mnemonic(
         nostr_npub,
     };
 
-    Ok(EncryptedWalletData {
+    Ok(DecryptedWalletData {
         mnemonic: mnemonic_phrase.to_string(),
         private,
         public,

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -51,11 +51,7 @@ pub async fn get_wallet(
     }
     drop(wallets_lock);
 
-    let change_descriptor = match change_descriptor {
-        Some(change_descriptor) => Some(&change_descriptor.0),
-        None => None,
-    };
-
+    let change_descriptor = change_descriptor.map(|change_descriptor| &change_descriptor.0);
     let new_wallet = Arc::new(Mutex::new(Wallet::new(
         &descriptor.0,
         change_descriptor,

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -27,7 +27,7 @@ static BDK: Lazy<Networks> = Lazy::new(Networks::default);
 
 pub async fn get_wallet(
     descriptor: &SecretString,
-    change_descriptor: Option<&SecretString>,
+    change_descriptor: Option<SecretString>,
 ) -> Result<Arc<Mutex<Wallet<MemoryDatabase>>>> {
     let descriptor_key = format!("{descriptor:?}{change_descriptor:?}");
     let key = sha256::Hash::hash(descriptor_key.as_bytes()).to_string();
@@ -51,7 +51,11 @@ pub async fn get_wallet(
     }
     drop(wallets_lock);
 
-    let change_descriptor = change_descriptor.map(|change_descriptor| &change_descriptor.0);
+    let mut change_descriptor = None;
+    if let Some(desc) = change_descriptor {
+        change_descriptor = Some(desc);
+    };
+
     let new_wallet = Arc::new(Mutex::new(Wallet::new(
         &descriptor.0,
         change_descriptor,

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -220,7 +220,7 @@ pub async fn create_psbt(sk: &str, request: PsbtRequest) -> Result<PsbtResponse>
     };
 
     let (psbt_file, change_terminal) = create_rgb_psbt(
-        descriptor_pub,
+        descriptor_pub.0.to_string(),
         asset_utxo,
         asset_utxo_terminal.clone(),
         change_index,

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -28,6 +28,7 @@ use wallet::{
 
 use crate::bitcoin::{get_wallet, synchronize_wallet};
 use crate::rgb::{constants::RGB_PSBT_TAPRET, structs::AddressAmount};
+use crate::structs::SecretString;
 
 #[allow(clippy::too_many_arguments)]
 pub fn create_psbt(
@@ -183,7 +184,7 @@ pub fn save_commit(terminal: &str, commit: Vec<u8>, wallet: &mut RgbWallet) {
 
 // TODO: [Experimental] Review with Diba Team
 pub async fn estimate_fee_tx(
-    descriptor_pub: &str,
+    descriptor_pub: &SecretString,
     asset_utxo: &str,
     asset_utxo_terminal: &str,
     change_index: Option<u16>,
@@ -235,7 +236,7 @@ pub async fn estimate_fee_tx(
 }
 
 fn get_recipient_script(
-    descriptor_pub: &str,
+    descriptor_pub: &SecretString,
     asset_utxo_terminal: &str,
     change_index: UnhardenedIndex,
 ) -> Option<Script> {
@@ -245,7 +246,8 @@ fn get_recipient_script(
 
     let contract_index = contract_terminal.first().expect("first derivation index");
     let terminal_step = format!("/{contract_index}/*");
-    let descriptor_pub = descriptor_pub.replace(&terminal_step, "/*/*");
+
+    let descriptor_pub = descriptor_pub.0.replace(&terminal_step, "/*/*");
     let descriptor: &Descriptor<DerivationAccount> =
         &Descriptor::from_str(&descriptor_pub).expect("invalid descriptor parse");
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use bdk::{Balance, BlockTime, TransactionDetails};
 pub use bitcoin::{util::address::Address, Txid};
@@ -26,7 +27,10 @@ pub struct WalletTransaction {
     pub confirmation_time: Option<BlockTime>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
+pub struct SecretString(pub String);
+
+#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateWalletData {
     pub xprvkh: String,
@@ -38,7 +42,7 @@ pub struct PrivateWalletData {
     pub nostr_nsec: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicWalletData {
     pub xpub: String,
@@ -52,9 +56,9 @@ pub struct PublicWalletData {
     pub nostr_npub: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
 #[serde(rename_all = "camelCase")]
-pub struct EncryptedWalletData {
+pub struct DecryptedWalletData {
     pub mnemonic: String,
     pub private: PrivateWalletData,
     pub public: PublicWalletData,
@@ -74,13 +78,6 @@ pub struct EncryptedWalletDataV04 {
     pub xprvkh: String,
     pub xpubkh: String,
     pub mnemonic: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct MnemonicSeedData {
-    pub mnemonic: String,
-    pub encrypted_descriptors: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -27,7 +27,8 @@ pub struct WalletTransaction {
     pub confirmation_time: Option<BlockTime>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
+#[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop, Display)]
+#[display(inner)]
 pub struct SecretString(pub String);
 
 #[derive(Serialize, Deserialize, Clone, Debug, Zeroize, ZeroizeOnDrop)]
@@ -355,7 +356,7 @@ pub struct InvoiceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct PsbtRequest {
     /// Descriptor XPub
-    pub descriptor_pub: String,
+    pub descriptor_pub: SecretString,
     /// Asset UTXO
     pub asset_utxo: String,
     /// Asset UTXO Terminal (ex. /0/0)
@@ -384,12 +385,8 @@ pub struct PsbtResponse {
 pub struct SignPsbtRequest {
     /// PSBT encoded in Base64
     pub psbt: String,
-    /// mnemonic
-    pub mnemonic: String,
-    /// password
-    pub seed_password: String,
-    /// iface
-    pub iface: String,
+    /// Descriptor to Sign
+    pub descriptor: SecretString,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -188,13 +188,10 @@ pub mod bitcoin {
     #[wasm_bindgen]
     pub fn get_wallet_data(descriptor: String, change_descriptor: Option<String>) -> Promise {
         set_panic_hook();
-
         future_to_promise(async move {
-            match crate::bitcoin::get_wallet_data(
-                &SecretString(descriptor),
-                Some(&SecretString(change_descriptor.unwrap_or_default())),
-            )
-            .await
+            let change_descriptor = change_descriptor.map(SecretString);
+            match crate::bitcoin::get_wallet_data(&SecretString(descriptor), change_descriptor)
+                .await
             {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),

--- a/src/web.rs
+++ b/src/web.rs
@@ -189,14 +189,12 @@ pub mod bitcoin {
     pub fn get_wallet_data(descriptor: String, change_descriptor: Option<String>) -> Promise {
         set_panic_hook();
 
-        let change_descriptor = match change_descriptor {
-            Some(descriptor) => Some(&SecretString(descriptor)),
-            None => None,
-        };
-
         future_to_promise(async move {
-            match crate::bitcoin::get_wallet_data(&SecretString(descriptor), change_descriptor)
-                .await
+            match crate::bitcoin::get_wallet_data(
+                &SecretString(descriptor),
+                Some(&SecretString(change_descriptor.unwrap_or_default())),
+            )
+            .await
             {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
@@ -339,12 +337,12 @@ pub mod rgb {
     }
 
     #[wasm_bindgen]
-    pub fn psbt_sign_file(nostr_hex_sk: String, request: JsValue) -> Promise {
+    pub fn psbt_sign_file(_nostr_hex_sk: String, request: JsValue) -> Promise {
         set_panic_hook();
 
         future_to_promise(async move {
             let psbt_req: SignPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
-            match crate::bitcoin::sign_psbt_file(&nostr_hex_sk, psbt_req).await {
+            match crate::bitcoin::sign_psbt_file(psbt_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -2,8 +2,9 @@
 
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::{get_encrypted_wallet, upgrade_wallet},
+    bitcoin::{decrypt_wallet, upgrade_wallet},
     constants::switch_network,
+    structs::SecretString,
     util::init_logging,
 };
 use log::{debug, info};
@@ -21,16 +22,29 @@ async fn migration_v4() -> Result<()> {
     switch_network("testnet").await?;
 
     info!("Import bitmask-core 0.4 encrypted descriptor");
-    let wallet = get_encrypted_wallet(ENCRYPTION_PASSWORD, ENCRYPTED_DESCRIPTOR_04);
+    let wallet = decrypt_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &SecretString(ENCRYPTED_DESCRIPTOR_04.to_owned()),
+    );
 
     assert!(wallet.is_err(), "Importing an old descriptor should error");
 
-    let upgraded_descriptor =
-        upgrade_wallet(ENCRYPTION_PASSWORD, ENCRYPTED_DESCRIPTOR_04, SEED_PASSWORD).await?;
+    let upgraded_descriptor = upgrade_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &SecretString(ENCRYPTED_DESCRIPTOR_04.to_owned()),
+        &SecretString(SEED_PASSWORD.to_owned()),
+    )
+    .await?;
 
-    debug!("Upgraded descriptor: {upgraded_descriptor}");
+    debug!(
+        "Upgraded descriptor: {}",
+        serde_json::to_string_pretty(&upgraded_descriptor)?
+    );
 
-    let wallet = get_encrypted_wallet(ENCRYPTION_PASSWORD, &upgraded_descriptor)?;
+    let wallet = decrypt_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &upgraded_descriptor,
+    )?;
 
     assert_eq!(
         wallet.public.xpub, "tpubD6NzVbkrYhZ4Xxrh54Ew5kjkagEfUhS3aCNqRJmUuNfnTXhK4LGXyUzZ5kxgn8f2txjnFtypnoYfRQ9Y8P2nhSNXffxVKutJgxNPxgmwpUR",
@@ -48,16 +62,29 @@ async fn migration_v5() -> Result<()> {
     switch_network("testnet").await?;
 
     info!("Import bitmask-core 0.5 encrypted descriptor");
-    let wallet = get_encrypted_wallet(ENCRYPTION_PASSWORD, ENCRYPTED_DESCRIPTOR_05);
+    let wallet = decrypt_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &SecretString(ENCRYPTED_DESCRIPTOR_05.to_owned()),
+    );
 
     assert!(wallet.is_err(), "Importing an old descriptor should error");
 
-    let upgraded_descriptor =
-        upgrade_wallet(ENCRYPTION_PASSWORD, ENCRYPTED_DESCRIPTOR_05, SEED_PASSWORD).await?;
+    let upgraded_descriptor = upgrade_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &SecretString(ENCRYPTED_DESCRIPTOR_05.to_owned()),
+        &SecretString(SEED_PASSWORD.to_owned()),
+    )
+    .await?;
 
-    println!("Upgraded descriptor: {upgraded_descriptor}");
+    println!(
+        "Upgraded descriptor: {}",
+        serde_json::to_string_pretty(&upgraded_descriptor)?
+    );
 
-    let wallet = get_encrypted_wallet(ENCRYPTION_PASSWORD, &upgraded_descriptor)?;
+    let wallet = decrypt_wallet(
+        &SecretString(ENCRYPTION_PASSWORD.to_owned()),
+        &upgraded_descriptor,
+    )?;
 
     assert_eq!(
         wallet.public.xpub, "tpubD6NzVbkrYhZ4XJmEMNjxuARFrP5kME8ndqpk9M2QeqtuTv2kTrm87a93Td47bHRRCrSSVvVEu3trvwthVswtPNwK2Kyc9PpudxC1MZrPuNL",

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -34,8 +34,10 @@ async fn payjoin() -> Result<()> {
     let vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
 
     let wallet = get_wallet_data(
-        &vault.private.btc_descriptor_xprv,
-        Some(vault.private.btc_change_descriptor_xprv.clone()),
+        &SecretString(vault.private.btc_descriptor_xprv.clone()),
+        Some(&SecretString(
+            vault.private.btc_change_descriptor_xprv.clone(),
+        )),
     )
     .await?;
     info!("Address: {}", wallet.address);
@@ -46,8 +48,8 @@ async fn payjoin() -> Result<()> {
     let amount = 1000;
 
     match send_sats(
-        &vault.private.btc_descriptor_xprv,
-        &vault.private.btc_change_descriptor_xprv,
+        &SecretString(vault.private.btc_descriptor_xprv.clone()),
+        &SecretString(vault.private.btc_change_descriptor_xprv.clone()),
         &destination,
         amount,
         Some(1.1),

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -35,7 +35,7 @@ async fn payjoin() -> Result<()> {
 
     let wallet = get_wallet_data(
         &SecretString(vault.private.btc_descriptor_xprv.clone()),
-        Some(&SecretString(
+        Some(SecretString(
             vault.private.btc_change_descriptor_xprv.clone(),
         )),
     )

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::{decrypt_wallet, encrypt_seed, get_wallet_data, hash_password, send_sats},
+    bitcoin::{decrypt_wallet, encrypt_wallet, get_wallet_data, hash_password, send_sats},
     constants::switch_network,
     structs::SecretString,
     util::init_logging,
@@ -24,7 +24,7 @@ async fn payjoin() -> Result<()> {
     info!("Import wallets");
     let mnemonic = env::var("TEST_WALLET_SEED")?;
     let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
-    let encrypted_descriptors = encrypt_seed(
+    let encrypted_descriptors = encrypt_wallet(
         &SecretString(mnemonic),
         &hash,
         &SecretString(SEED_PASSWORD.to_owned()),

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -11,6 +11,7 @@ mod rgb {
     mod integration {
         // TODO: Review after support multi-token transfer
         // mod collectibles;
+        mod collectibles;
         mod fungibles;
         mod import;
         mod issue;

--- a/tests/rgb/integration/collectibles.rs
+++ b/tests/rgb/integration/collectibles.rs
@@ -1,40 +1,42 @@
 #![cfg(not(target_arch = "wasm32"))]
-use crate::rgb::integration::utils::{
-    create_new_invoice, create_new_psbt, create_new_transfer, get_collectible_data,
-    issuer_issue_contract, ISSUER_MNEMONIC,
-};
-use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
-    rgb::accept_transfer,
-    structs::{AcceptRequest, SignPsbtRequest},
-};
+// use crate::rgb::integration::utils::{
+//     create_new_invoice, create_new_psbt, create_new_transfer, issuer_issue_contract,
+//     ISSUER_MNEMONIC,
+// };
+// use bitmask_core::{
+//     bitcoin::{save_mnemonic, sign_psbt_file},
+//     rgb::accept_transfer,
+//     structs::{AcceptRequest, SecretString, SignPsbtRequest},
+// };
 
-#[tokio::test]
-async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
-    let collectible = Some(get_collectible_data());
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await?;
-    let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
-    let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
-    let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
+// #[tokio::test]
+// async fn _allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
+//     let collectible = Some(get_collectible_data());
+//     let issuer_keys = save_mnemonic(
+//         &SecretString(ISSUER_MNEMONIC.to_string()),
+//         &SecretString("".to_string()),
+//     )
+//     .await?;
+//     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await?;
+//     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
+//     let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
+//     let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
 
-    let sk = issuer_keys.private.nostr_prv.to_string();
-    let request = SignPsbtRequest {
-        psbt: transfer_resp.psbt,
-        mnemonic: ISSUER_MNEMONIC.to_string(),
-        seed_password: String::new(),
-        iface: issuer_resp.iface,
-    };
-    let resp = sign_psbt_file(&sk, request).await;
-    assert!(resp.is_ok());
+//     let sk = issuer_keys.private.nostr_prv.to_string();
+//     let request = SignPsbtRequest {
+//         psbt: transfer_resp.psbt,
+//         descriptor: SecretString(issuer_keys.private.rgb_udas_descriptor_xprv),
+//     };
+//     let resp = sign_psbt_file(request).await;
+//     assert!(resp.is_ok());
 
-    let request = AcceptRequest {
-        consignment: transfer_resp.consig,
-        force: false,
-    };
+//     let request = AcceptRequest {
+//         consignment: transfer_resp.consig,
+//         force: false,
+//     };
 
-    let resp = accept_transfer(&sk, request).await;
-    assert!(resp.is_ok());
-    assert!(resp?.valid);
-    Ok(())
-}
+//     let resp = accept_transfer(&sk, request).await;
+//     assert!(resp.is_ok());
+//     assert!(resp?.valid);
+//     Ok(())
+// }

--- a/tests/rgb/integration/import.rs
+++ b/tests/rgb/integration/import.rs
@@ -2,7 +2,7 @@
 use bitmask_core::{
     bitcoin::{save_mnemonic, sign_psbt_file},
     rgb::{accept_transfer, create_watcher, get_contract},
-    structs::{AcceptRequest, EncryptedWalletData, SignPsbtRequest, WatcherRequest},
+    structs::{AcceptRequest, DecryptedWalletData, SignPsbtRequest, WatcherRequest},
 };
 
 use crate::rgb::integration::utils::{
@@ -45,7 +45,7 @@ async fn allow_import_uda_contract() -> anyhow::Result<()> {
 #[tokio::test]
 async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     // 1. Issue and Generate Trasnfer (Issuer side)
-    let issuer_keys: EncryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys: DecryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
     let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
     let issuer_resp = issuer_issue_contract("RGB20", 5, false, true, None).await?;
     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
@@ -110,7 +110,7 @@ async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<
 async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     // 1. Issue and Generate Trasnfer (Issuer side)
     let single = Some(get_uda_data());
-    let issuer_keys: EncryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys: DecryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
     let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, single).await?;
     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;

--- a/tests/rgb/integration/import.rs
+++ b/tests/rgb/integration/import.rs
@@ -2,7 +2,7 @@
 use bitmask_core::{
     bitcoin::{save_mnemonic, sign_psbt_file},
     rgb::{accept_transfer, create_watcher, get_contract},
-    structs::{AcceptRequest, DecryptedWalletData, SignPsbtRequest, WatcherRequest},
+    structs::{AcceptRequest, DecryptedWalletData, SecretString, SignPsbtRequest, WatcherRequest},
 };
 
 use crate::rgb::integration::utils::{
@@ -45,23 +45,29 @@ async fn allow_import_uda_contract() -> anyhow::Result<()> {
 #[tokio::test]
 async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     // 1. Issue and Generate Trasnfer (Issuer side)
-    let issuer_keys: DecryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
+    let issuer_keys: DecryptedWalletData = save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let owner_keys = save_mnemonic(
+        &SecretString(OWNER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
     let issuer_resp = issuer_issue_contract("RGB20", 5, false, true, None).await?;
     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
     let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
-    let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
+    let transfer_resp = &create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
 
     // 2. Sign and Publish TX (Issuer side)
     let issuer_sk = issuer_keys.private.nostr_prv.to_string();
     let owner_sk = owner_keys.private.nostr_prv.to_string();
     let request = SignPsbtRequest {
-        psbt: transfer_resp.clone().psbt,
-        mnemonic: ISSUER_MNEMONIC.to_string(),
-        seed_password: String::new(),
-        iface: issuer_resp.iface,
+        psbt: transfer_resp.psbt.clone(),
+        descriptor: SecretString(issuer_keys.private.rgb_assets_descriptor_xprv.clone()),
     };
-    let resp = sign_psbt_file(&issuer_sk, request).await;
+    let resp = sign_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 3. Accept Consig (Issuer Side)
@@ -75,7 +81,7 @@ async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<
 
     // 4. Accept Consig (Owner Side)
     let request = AcceptRequest {
-        consignment: transfer_resp.consig,
+        consignment: transfer_resp.consig.clone(),
         force: false,
     };
     let resp = accept_transfer(&owner_sk, request).await;
@@ -92,7 +98,7 @@ async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<
     let watcher_name = "default";
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: owner_keys.public.watcher_xpub,
+        xpub: owner_keys.public.watcher_xpub.clone(),
         force: true,
     };
     create_watcher(&owner_sk, create_watch_req).await?;
@@ -110,28 +116,35 @@ async fn allow_get_fungible_contract_state_by_accept_cosign() -> anyhow::Result<
 async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     // 1. Issue and Generate Trasnfer (Issuer side)
     let single = Some(get_uda_data());
-    let issuer_keys: DecryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
+    let issuer_keys: DecryptedWalletData = save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let owner_keys = save_mnemonic(
+        &SecretString(OWNER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+
     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, single).await?;
     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;
     let psbt_resp = create_new_psbt(issuer_keys.clone(), issuer_resp.clone()).await?;
-    let transfer_resp = create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
+    let transfer_resp = &create_new_transfer(issuer_keys.clone(), owner_resp, psbt_resp).await?;
 
     // 2. Sign and Publish TX (Issuer side)
     let issuer_sk = issuer_keys.private.nostr_prv.to_string();
     let owner_sk = owner_keys.private.nostr_prv.to_string();
     let request = SignPsbtRequest {
-        psbt: transfer_resp.clone().psbt,
-        mnemonic: ISSUER_MNEMONIC.to_string(),
-        seed_password: String::new(),
-        iface: issuer_resp.iface,
+        psbt: transfer_resp.psbt.clone(),
+        descriptor: SecretString(issuer_keys.private.rgb_udas_descriptor_xprv.clone()),
     };
-    let resp = sign_psbt_file(&issuer_sk, request).await;
+    let resp = sign_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 3. Accept Consig (Issuer Side)
     let request = AcceptRequest {
-        consignment: transfer_resp.clone().consig,
+        consignment: transfer_resp.consig.clone(),
         force: false,
     };
     let resp = accept_transfer(&issuer_sk, request).await;
@@ -140,7 +153,7 @@ async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
 
     // 4. Accept Consig (Owner Side)
     let request = AcceptRequest {
-        consignment: transfer_resp.consig,
+        consignment: transfer_resp.consig.clone(),
         force: false,
     };
     let resp = accept_transfer(&owner_sk, request).await;
@@ -157,7 +170,7 @@ async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
     let watcher_name = "default";
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: owner_keys.public.watcher_xpub,
+        xpub: owner_keys.public.watcher_xpub.clone(),
         force: true,
     };
     create_watcher(&owner_sk, create_watch_req).await?;
@@ -175,7 +188,7 @@ async fn allow_get_uda_contract_state_by_accept_cosign() -> anyhow::Result<()> {
 // async fn _allow_get_collectible_contract_state_by_accept_cosign() -> anyhow::Result<()> {
 //     // 1. Issue and Generate Trasnfer (Issuer side)
 //     let collectible = Some(get_collectible_data());
-//     let issuer_keys: EncryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+//     let issuer_keys: DecryptedWalletData = save_mnemonic(ISSUER_MNEMONIC, "").await?;
 //     let owner_keys = save_mnemonic(OWNER_MNEMONIC, "").await?;
 //     let issuer_resp = issuer_issue_contract("RGB21", 1, false, true, collectible).await?;
 //     let owner_resp = create_new_invoice(issuer_resp.clone(), None).await?;

--- a/tests/rgb/integration/stress.rs
+++ b/tests/rgb/integration/stress.rs
@@ -8,7 +8,7 @@ use bitmask_core::{
     rgb::{
         clear_stock, clear_watcher, constants::RGB_DEFAULT_NAME, create_watcher, list_contracts,
     },
-    structs::{IssueResponse, WatcherRequest},
+    structs::{IssueResponse, SecretString, WatcherRequest},
 };
 use psbt::Psbt;
 
@@ -29,13 +29,17 @@ async fn allow_issue_x_fungibles_in_one_utxo() -> anyhow::Result<()> {
 
     let max = 150;
     let supply = 5;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
     let iface = "RGB20";
-    let watcher_pub = issuer_keys.public.watcher_xpub;
+    let watcher_pub = issuer_keys.public.watcher_xpub.clone();
     send_coins(iface, &watcher_pub).await?;
 
     let mut contracts = HashMap::new();
@@ -81,8 +85,12 @@ async fn allow_issue_x_fungibles_generate_utxos() -> anyhow::Result<()> {
 
     let max = 26;
     let supply = 5;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
@@ -128,8 +136,13 @@ async fn allow_issue_x_fungibles_witn_spend_utxos() -> anyhow::Result<()> {
 
     let max = 26;
     let supply = 5;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.clone().private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
@@ -151,7 +164,11 @@ async fn allow_issue_x_fungibles_witn_spend_utxos() -> anyhow::Result<()> {
     let original_psbt = Psbt::from_str(&psbt_resp.psbt)?;
     let final_psbt = PartiallySignedTransaction::from(original_psbt);
 
-    let issuer_wallet = get_wallet(&issuer_keys.private.rgb_assets_descriptor_xprv, None).await?;
+    let issuer_wallet = get_wallet(
+        &SecretString(issuer_keys.private.rgb_assets_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
     synchronize_wallet(&issuer_wallet).await?;
 
     let sign = sign_psbt(&issuer_wallet, final_psbt).await;
@@ -196,13 +213,17 @@ async fn allow_import_fungible_before_create_watcher() -> anyhow::Result<()> {
     }
 
     let supply = 5;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
     let iface = "RGB20";
-    let watcher_pub = issuer_keys.public.watcher_xpub;
+    let watcher_pub = issuer_keys.public.watcher_xpub.clone();
     send_coins(iface, &watcher_pub).await?;
 
     let issuer_resp = issuer_issue_contract(iface, supply, false, false, None).await;
@@ -261,13 +282,17 @@ async fn allow_issue_x_uda_in_one_utxo() -> anyhow::Result<()> {
 
     let max = 150;
     let supply = 1;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
     let iface = "RGB21";
-    let watcher_pub = issuer_keys.public.watcher_xpub;
+    let watcher_pub = issuer_keys.public.watcher_xpub.clone();
     send_coins(iface, &watcher_pub).await?;
 
     let mut contracts = HashMap::new();
@@ -313,8 +338,12 @@ async fn allow_issue_x_uda_generate_utxos() -> anyhow::Result<()> {
 
     let max = 26;
     let supply = 1;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
@@ -360,8 +389,12 @@ async fn allow_issue_x_uda_witn_spend_utxos() -> anyhow::Result<()> {
 
     let max = 26;
     let supply = 1;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.clone().private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
@@ -383,7 +416,11 @@ async fn allow_issue_x_uda_witn_spend_utxos() -> anyhow::Result<()> {
     let original_psbt = Psbt::from_str(&psbt_resp.psbt)?;
     let final_psbt = PartiallySignedTransaction::from(original_psbt);
 
-    let issuer_wallet = get_wallet(&issuer_keys.private.rgb_udas_descriptor_xprv, None).await?;
+    let issuer_wallet = get_wallet(
+        &SecretString(issuer_keys.private.rgb_udas_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
     synchronize_wallet(&issuer_wallet).await?;
 
     let sign = sign_psbt(&issuer_wallet, final_psbt).await;
@@ -428,13 +465,17 @@ async fn allow_import_uda_before_create_watcher() -> anyhow::Result<()> {
     }
 
     let supply = 1;
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
-    let issuer_sk = issuer_keys.private.nostr_prv;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
+    let issuer_sk = issuer_keys.private.nostr_prv.clone();
     clear_stock(&issuer_sk).await;
     clear_watcher(&issuer_sk, "default").await?;
 
     let iface = "RGB21";
-    let watcher_pub = issuer_keys.public.watcher_xpub;
+    let watcher_pub = issuer_keys.public.watcher_xpub.clone();
     send_coins(iface, &watcher_pub).await?;
 
     let issuer_resp = issuer_issue_contract(iface, supply, false, false, None).await;

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -9,7 +9,7 @@ use bitmask_core::{
         watcher_details, watcher_next_address, watcher_next_utxo,
     },
     structs::{
-        AllocationDetail, AssetType, ContractResponse, EncryptedWalletData, ImportRequest,
+        AllocationDetail, AssetType, ContractResponse, DecryptedWalletData, ImportRequest,
         InvoiceRequest, InvoiceResponse, IssueMetaRequest, IssueMetadata, IssueRequest,
         IssueResponse, MediaInfo, NewCollectible, PsbtRequest, PsbtResponse, RgbTransferRequest,
         RgbTransferResponse, WatcherRequest,
@@ -260,7 +260,7 @@ pub async fn create_new_invoice(
 }
 
 pub async fn create_new_psbt(
-    issuer_keys: EncryptedWalletData,
+    issuer_keys: DecryptedWalletData,
     issuer_resp: IssueResponse,
 ) -> Result<PsbtResponse, anyhow::Error> {
     // Get Allocations
@@ -311,7 +311,7 @@ pub async fn create_new_psbt(
 }
 
 pub async fn create_new_transfer(
-    issuer_keys: EncryptedWalletData,
+    issuer_keys: DecryptedWalletData,
     owner_resp: InvoiceResponse,
     psbt_resp: PsbtResponse,
 ) -> Result<RgbTransferResponse, anyhow::Error> {

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -126,7 +126,7 @@ pub async fn send_coins(iface: &str, _watcher_pub: &str) -> anyhow::Result<()> {
 
     // Send Coins
     let sk = &issuer_keys.private.nostr_prv;
-    let next_address = watcher_next_address(&sk, watcher_name, iface).await?;
+    let next_address = watcher_next_address(sk, watcher_name, iface).await?;
     send_some_coins(&next_address.address, "0.01").await;
     Ok(())
 }
@@ -154,19 +154,19 @@ pub async fn issuer_issue_contract(
         force: send_coins,
     };
 
-    create_watcher(&sk, create_watch_req.clone()).await?;
+    create_watcher(sk, create_watch_req.clone()).await?;
 
     if send_coins {
-        let next_address = watcher_next_address(&sk, watcher_name, iface).await?;
+        let next_address = watcher_next_address(sk, watcher_name, iface).await?;
         send_some_coins(&next_address.address, "0.01").await;
     }
 
-    let mut next_utxo = watcher_next_utxo(&sk, watcher_name, iface).await?;
+    let mut next_utxo = watcher_next_utxo(sk, watcher_name, iface).await?;
     if next_utxo.utxo.is_empty() {
-        let next_address = watcher_next_address(&sk, watcher_name, iface).await?;
+        let next_address = watcher_next_address(sk, watcher_name, iface).await?;
         send_some_coins(&next_address.address, "0.01").await;
 
-        next_utxo = watcher_next_utxo(&sk, watcher_name, iface).await?;
+        next_utxo = watcher_next_utxo(sk, watcher_name, iface).await?;
     }
 
     let issue_utxo = next_utxo.utxo;
@@ -182,7 +182,7 @@ pub async fn issuer_issue_contract(
         meta,
     };
 
-    issue_contract(&sk, request).await
+    issue_contract(sk, request).await
 }
 
 pub async fn import_new_contract(

--- a/tests/rgb/integration/watcher.rs
+++ b/tests/rgb/integration/watcher.rs
@@ -2,28 +2,33 @@
 use bitmask_core::{
     bitcoin::{get_wallet, save_mnemonic, synchronize_wallet},
     rgb::{create_watcher, watcher_address, watcher_next_address, watcher_next_utxo, watcher_utxo},
-    structs::WatcherRequest,
+    structs::{SecretString, WatcherRequest},
 };
 
 use crate::rgb::integration::utils::{send_some_coins, ISSUER_MNEMONIC};
 
 #[tokio::test]
 async fn allow_monitoring_address() -> anyhow::Result<()> {
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     // Create Watcher
     let watcher_name = "default";
-    let sk = issuer_keys.private.nostr_prv;
+    let sk = issuer_keys.private.nostr_prv.clone();
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: issuer_keys.public.watcher_xpub,
+        xpub: issuer_keys.public.watcher_xpub.clone(),
         force: true,
     };
 
     create_watcher(&sk, create_watch_req.clone()).await?;
 
     // Get Address
-    let issuer_wallet = get_wallet(&issuer_keys.private.btc_descriptor_xprv, None).await?;
+    let desc = SecretString(issuer_keys.private.btc_descriptor_xprv.clone());
+    let issuer_wallet = get_wallet(&desc, None).await?;
     synchronize_wallet(&issuer_wallet).await?;
 
     let address = issuer_wallet
@@ -40,21 +45,26 @@ async fn allow_monitoring_address() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn allow_monitoring_address_with_coins() -> anyhow::Result<()> {
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     // Create Watcher
     let watcher_name = "default";
-    let sk = issuer_keys.private.nostr_prv;
+    let sk = issuer_keys.private.nostr_prv.clone();
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: issuer_keys.public.watcher_xpub,
+        xpub: issuer_keys.public.watcher_xpub.clone(),
         force: true,
     };
 
     create_watcher(&sk, create_watch_req.clone()).await?;
 
     // Get Address
-    let issuer_wallet = get_wallet(&issuer_keys.private.btc_descriptor_xprv, None).await?;
+    let desc = SecretString(issuer_keys.private.btc_descriptor_xprv.clone());
+    let issuer_wallet = get_wallet(&desc, None).await?;
     synchronize_wallet(&issuer_wallet).await?;
     let address = issuer_wallet
         .lock()
@@ -74,14 +84,18 @@ async fn allow_monitoring_address_with_coins() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn allow_monitoring_invalid_utxo() -> anyhow::Result<()> {
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     // Create Watcher
     let watcher_name = "default";
-    let sk = issuer_keys.private.nostr_prv;
+    let sk = issuer_keys.private.nostr_prv.clone();
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: issuer_keys.public.watcher_xpub,
+        xpub: issuer_keys.public.watcher_xpub.clone(),
         force: true,
     };
     create_watcher(&sk, create_watch_req.clone()).await?;
@@ -101,14 +115,18 @@ async fn allow_monitoring_invalid_utxo() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn allow_monitoring_valid_utxo() -> anyhow::Result<()> {
-    let issuer_keys = save_mnemonic(ISSUER_MNEMONIC, "").await?;
+    let issuer_keys = &save_mnemonic(
+        &SecretString(ISSUER_MNEMONIC.to_string()),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     // Create Watcher
     let watcher_name = "default";
-    let sk = issuer_keys.private.nostr_prv;
+    let sk = issuer_keys.private.nostr_prv.clone();
     let create_watch_req = WatcherRequest {
         name: watcher_name.to_string(),
-        xpub: issuer_keys.public.watcher_xpub,
+        xpub: issuer_keys.public.watcher_xpub.clone(),
         force: true,
     };
     create_watcher(&sk, create_watch_req.clone()).await?;

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -3,10 +3,9 @@ use std::env;
 
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::{
-        get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed, save_mnemonic_seed,
-    },
+    bitcoin::{encrypt_seed, get_encrypted_wallet, get_wallet_data, hash_password, new_wallet},
     constants::{get_network, switch_network},
+    structs::SecretString,
     util::init_logging,
     warn,
 };
@@ -24,8 +23,9 @@ async fn error_for_bad_mnemonic() -> Result<()> {
 
     info!("Import wallets");
     let mnemonic = "this is a bad mnemonic that is meant to break";
-    let hash = hash_password(ENCRYPTION_PASSWORD);
-    let mnemonic_data_result = save_mnemonic_seed(mnemonic, &hash, SEED_PASSWORD).await;
+    let hash = hash_password(SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    let mnemonic_data_result =
+        encrypt_seed(&SecretString(mnemonic), &hash, &SecretString(SEED_PASSWORD)).await;
 
     assert!(mnemonic_data_result.is_err());
 
@@ -41,12 +41,11 @@ async fn create_wallet() -> Result<()> {
     info!("Asset test on {network}");
 
     info!("Create wallet");
-    let hash = hash_password(ENCRYPTION_PASSWORD);
-    let main_mnemonic = new_mnemonic_seed(&hash, SEED_PASSWORD).await?;
+    let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD));
+    let main_mnemonic = new_wallet(&hash, &SecretString(SEED_PASSWORD)).await?;
     info!("Generated mnemonic: {}", main_mnemonic.mnemonic);
-    let main_mnemonic_data =
-        save_mnemonic_seed(&main_mnemonic.mnemonic, &hash, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
+    let encrypted_descriptors = encrypt_seed(&main_mnemonic.mnemonic, &hash, SEED_PASSWORD).await?;
+    let main_vault = get_encrypted_wallet(&hash, &encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
     // let main_rgb_wallet =
@@ -69,7 +68,7 @@ async fn import_wallet() -> Result<()> {
     info!("Import wallets");
     let main_mnemonic = env::var("TEST_WALLET_SEED")?;
     let hash0 = hash_password(ENCRYPTION_PASSWORD);
-    let main_mnemonic_data = save_mnemonic_seed(&main_mnemonic, &hash0, SEED_PASSWORD).await?;
+    let main_mnemonic_data = encrypt_seed(&main_mnemonic, &hash0, SEED_PASSWORD).await?;
     let _main_vault = get_encrypted_wallet(&hash0, &main_mnemonic_data.encrypted_descriptors)?;
 
     info!("Try once more");
@@ -77,7 +76,7 @@ async fn import_wallet() -> Result<()> {
     assert_eq!(hash0, hash1, "hashes match");
 
     let main_mnemonic_data: bitmask_core::structs::MnemonicSeedData =
-        save_mnemonic_seed(&main_mnemonic, &hash1, SEED_PASSWORD).await?;
+        encrypt_seed(&main_mnemonic, &hash1, SEED_PASSWORD).await?;
     let main_vault = get_encrypted_wallet(&hash1, &main_mnemonic_data.encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
@@ -97,7 +96,7 @@ async fn get_wallet_balance() -> Result<()> {
 
     let main_mnemonic = env::var("TEST_WALLET_SEED")?;
     let hash = hash_password(ENCRYPTION_PASSWORD);
-    let main_mnemonic_data = save_mnemonic_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
+    let main_mnemonic_data = encrypt_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
     let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -48,21 +48,12 @@ async fn create_wallet() -> Result<()> {
     let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     let encrypted_descriptors = new_wallet(&hash, &SecretString(SEED_PASSWORD.to_owned())).await?;
     let decrypted_wallet = decrypt_wallet(&hash, &encrypted_descriptors)?;
-    let wallet_data = get_wallet_data(
-        &decrypted_wallet.private.btc_descriptor_xprv,
-        Some(&decrypted_wallet.private.btc_change_descriptor_xprv),
-    )
-    .await?;
-    info!("Generated mnemonic: {}", decrypted_wallet.mnemonic);
-    let encrypted_descriptors = encrypt_wallet(
-        &SecretString(decrypted_wallet.mnemonic),
-        &hash,
-        &SecretString(SEED_PASSWORD.to_owned()),
-    )
-    .await?;
 
-    let main_btc_wallet =
-        get_wallet_data(&decrypted_wallet.private.btc_descriptor_xprv, None).await?;
+    let main_btc_wallet = get_wallet_data(
+        &SecretString(decrypted_wallet.private.btc_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
     // let main_rgb_wallet =
     //     get_wallet_data(&decrypted_wallet.private.rgb_assets_descriptor_xprv, None).await?;
 
@@ -97,9 +88,16 @@ async fn import_wallet() -> Result<()> {
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash1, &seed_password).await?;
     let main_vault = decrypt_wallet(&hash1, &encrypted_descriptors)?;
 
-    let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
-    let main_rgb_wallet =
-        get_wallet_data(&main_vault.private.rgb_assets_descriptor_xprv, None).await?;
+    let main_btc_wallet = get_wallet_data(
+        &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
+    let main_rgb_wallet = get_wallet_data(
+        &SecretString(main_vault.private.rgb_assets_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
 
     println!("Descriptor: {}", main_vault.private.btc_descriptor_xprv);
     println!("Address (Bitcoin): {}", main_btc_wallet.address);
@@ -118,9 +116,17 @@ async fn get_wallet_balance() -> Result<()> {
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash, &seed_password).await?;
     let main_vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
 
-    let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
+    let main_btc_wallet = get_wallet_data(
+        &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
 
-    let btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
+    let btc_wallet = get_wallet_data(
+        &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
+        None,
+    )
+    .await?;
     warn!("Descriptor:", main_vault.private.btc_descriptor_xprv);
     warn!("Address:", main_btc_wallet.address);
     warn!("Wallet Balance:", btc_wallet.balance.confirmed.to_string());

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -3,7 +3,7 @@ use std::env;
 
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::{encrypt_seed, get_encrypted_wallet, get_wallet_data, hash_password, new_wallet},
+    bitcoin::{decrypt_wallet, encrypt_wallet, get_wallet_data, hash_password, new_wallet},
     constants::{get_network, switch_network},
     structs::SecretString,
     util::init_logging,
@@ -23,9 +23,13 @@ async fn error_for_bad_mnemonic() -> Result<()> {
 
     info!("Import wallets");
     let mnemonic = "this is a bad mnemonic that is meant to break";
-    let hash = hash_password(SecretString(ENCRYPTION_PASSWORD.to_owned()));
-    let mnemonic_data_result =
-        encrypt_seed(&SecretString(mnemonic), &hash, &SecretString(SEED_PASSWORD)).await;
+    let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    let mnemonic_data_result = encrypt_wallet(
+        &SecretString(mnemonic.to_owned()),
+        &hash,
+        &SecretString(SEED_PASSWORD.to_owned()),
+    )
+    .await;
 
     assert!(mnemonic_data_result.is_err());
 
@@ -41,17 +45,31 @@ async fn create_wallet() -> Result<()> {
     info!("Asset test on {network}");
 
     info!("Create wallet");
-    let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD));
-    let main_mnemonic = new_wallet(&hash, &SecretString(SEED_PASSWORD)).await?;
-    info!("Generated mnemonic: {}", main_mnemonic.mnemonic);
-    let encrypted_descriptors = encrypt_seed(&main_mnemonic.mnemonic, &hash, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash, &encrypted_descriptors)?;
+    let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    let encrypted_descriptors = new_wallet(&hash, &SecretString(SEED_PASSWORD.to_owned())).await?;
+    let decrypted_wallet = decrypt_wallet(&hash, &encrypted_descriptors)?;
+    let wallet_data = get_wallet_data(
+        &decrypted_wallet.private.btc_descriptor_xprv,
+        Some(&decrypted_wallet.private.btc_change_descriptor_xprv),
+    )
+    .await?;
+    info!("Generated mnemonic: {}", decrypted_wallet.mnemonic);
+    let encrypted_descriptors = encrypt_wallet(
+        &SecretString(decrypted_wallet.mnemonic),
+        &hash,
+        &SecretString(SEED_PASSWORD.to_owned()),
+    )
+    .await?;
 
-    let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
+    let main_btc_wallet =
+        get_wallet_data(&decrypted_wallet.private.btc_descriptor_xprv, None).await?;
     // let main_rgb_wallet =
-    //     get_wallet_data(&main_vault.private.rgb_assets_descriptor_xprv, None).await?;
+    //     get_wallet_data(&decrypted_wallet.private.rgb_assets_descriptor_xprv, None).await?;
 
-    println!("Descriptor: {}", main_vault.private.btc_descriptor_xprv);
+    println!(
+        "Descriptor: {}",
+        decrypted_wallet.private.btc_descriptor_xprv
+    );
     println!("Address (Bitcoin): {}", main_btc_wallet.address);
     // println!("Address (RGB): {}", main_rgb_wallet.address);
 
@@ -66,18 +84,18 @@ async fn import_wallet() -> Result<()> {
     info!("Asset test on {network}");
 
     info!("Import wallets");
-    let main_mnemonic = env::var("TEST_WALLET_SEED")?;
-    let hash0 = hash_password(ENCRYPTION_PASSWORD);
-    let main_mnemonic_data = encrypt_seed(&main_mnemonic, &hash0, SEED_PASSWORD).await?;
-    let _main_vault = get_encrypted_wallet(&hash0, &main_mnemonic_data.encrypted_descriptors)?;
+    let seed_password = SecretString(SEED_PASSWORD.to_owned());
+    let main_mnemonic = SecretString(env::var("TEST_WALLET_SEED")?);
+    let hash0 = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash0, &seed_password).await?;
+    let _main_vault = decrypt_wallet(&hash0, &encrypted_descriptors)?;
 
     info!("Try once more");
-    let hash1 = hash_password(ENCRYPTION_PASSWORD);
-    assert_eq!(hash0, hash1, "hashes match");
+    let hash1 = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    assert_eq!(hash0.0, hash1.0, "hashes match");
 
-    let main_mnemonic_data: bitmask_core::structs::MnemonicSeedData =
-        encrypt_seed(&main_mnemonic, &hash1, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash1, &main_mnemonic_data.encrypted_descriptors)?;
+    let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash1, &seed_password).await?;
+    let main_vault = decrypt_wallet(&hash1, &encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
     let main_rgb_wallet =
@@ -94,10 +112,11 @@ async fn import_wallet() -> Result<()> {
 async fn get_wallet_balance() -> Result<()> {
     init_logging("wallet=info");
 
-    let main_mnemonic = env::var("TEST_WALLET_SEED")?;
-    let hash = hash_password(ENCRYPTION_PASSWORD);
-    let main_mnemonic_data = encrypt_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
-    let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
+    let main_mnemonic = SecretString(env::var("TEST_WALLET_SEED")?);
+    let seed_password = SecretString(SEED_PASSWORD.to_owned());
+    let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
+    let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash, &seed_password).await?;
+    let main_vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
 

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -1,7 +1,7 @@
 #![cfg(all(target_arch = "wasm32"))]
 use bitmask_core::{
     debug, info,
-    structs::{EncryptedWalletData, MnemonicSeedData, TransactionDetails, WalletData},
+    structs::{DecryptedWalletData, MnemonicSeedData, TransactionDetails, WalletData},
     web::{
         bitcoin::{
             get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed,


### PR DESCRIPTION
- [x] Implement secrets zeroization with SecretString newtype.
- [x] Avoid returning the mnemonic on encrypted descriptors (this should just be decrypted)
- [x] Utilize getrandom entropy (which pulls entropy from the system).
- [x] Switch to mandatory 24 word seeds.
- [x] Tests updated
- [x] bitmaskd updated

The following methods have been renamed to make them clearer:

- `new_mnemonic_seed` -> `new_wallet`
- `save_mnemonic_seed` -> `encrypt_wallet`
- `get_encrypted_wallet` -> `decrypt_wallet`

I realize some of these changes can be inconvenient, but making the wallet secure is worth it.

Resolves #240 