### PR TITLE
Separate wallet syncing

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -68,11 +68,9 @@ pub fn decrypt_wallet(
     hash: &SecretString,
     encrypted_descriptors: &SecretString,
 ) -> Result<DecryptedWalletData> {
-    // let hash: &str = hash.0.as_ref();
     let mut shared_key: [u8; 32] = hex::decode(&hash.0)?
         .try_into()
         .expect("hash is of fixed size");
-    // let encrypted_descriptors: &str = encrypted_descriptors.0.as_ref();
     let encrypted_descriptors: Vec<u8> = hex::decode(&encrypted_descriptors.0)?;
     let (version_prefix, encrypted_descriptors) = encrypted_descriptors.split_at(5);
 
@@ -177,7 +175,7 @@ pub async fn encrypt_wallet(
 
 pub async fn get_wallet_data(
     descriptor: &SecretString,
-    change_descriptor: Option<SecretString>,
+    change_descriptor: Option<&SecretString>,
 ) -> Result<WalletData> {
     info!("get_wallet_data");
 
@@ -234,7 +232,7 @@ pub async fn get_wallet_data(
 
 pub async fn get_new_address(
     descriptor: &SecretString,
-    change_descriptor: Option<SecretString>,
+    change_descriptor: Option<&SecretString>,
 ) -> Result<String> {
     info!("get_new_address");
 
@@ -257,7 +255,7 @@ pub async fn send_sats(
 ) -> Result<TransactionDetails> {
     use payjoin::UriExt;
 
-    let wallet = get_wallet(descriptor, Some(change_descriptor.to_owned())).await?;
+    let wallet = get_wallet(descriptor, Some(change_descriptor)).await?;
     let fee_rate = fee_rate.map(FeeRate::from_sat_per_vb);
 
     let transaction = match payjoin::Uri::try_from(destination) {
@@ -296,11 +294,7 @@ pub async fn fund_vault(
     let assets_address = Address::from_str(assets_address)?;
     let uda_address = Address::from_str(uda_address)?;
 
-    let wallet = get_wallet(
-        btc_descriptor_xprv,
-        Some(btc_change_descriptor_xprv.clone()),
-    )
-    .await?;
+    let wallet = get_wallet(btc_descriptor_xprv, Some(btc_change_descriptor_xprv)).await?;
 
     let asset_invoice = SatsInvoice {
         address: assets_address,

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -21,7 +21,7 @@ pub use crate::bitcoin::{
     keys::{new_mnemonic, save_mnemonic},
     payment::{create_payjoin, create_transaction},
     psbt::sign_psbt,
-    wallet::{get_blockchain, get_wallet, sync_wallets, MemoryWallet},
+    wallet::{get_blockchain, get_wallet, sync_wallet, sync_wallets, MemoryWallet},
 };
 
 use crate::{

--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -6,7 +6,7 @@ use payjoin::{PjUri, PjUriExt};
 use crate::{
     bitcoin::{
         psbt::{sign_original_psbt, sign_psbt},
-        wallet::{synchronize_wallet, MemoryWallet},
+        wallet::MemoryWallet,
     },
     debug, info,
     structs::SatsInvoice,
@@ -17,7 +17,6 @@ pub async fn create_transaction(
     wallet: &MemoryWallet,
     fee_rate: Option<FeeRate>,
 ) -> Result<TransactionDetails> {
-    synchronize_wallet(wallet).await?;
     let (psbt, details) = {
         let locked_wallet = wallet.lock().await;
         let mut builder = locked_wallet.build_tx();

--- a/src/bitcoin/psbt.rs
+++ b/src/bitcoin/psbt.rs
@@ -3,7 +3,7 @@ use bdk::{blockchain::Blockchain, psbt::PsbtUtils, SignOptions, TransactionDetai
 use bitcoin::{consensus::serialize, util::psbt::PartiallySignedTransaction};
 
 use crate::{
-    bitcoin::{get_blockchain, synchronize_wallet, MemoryWallet},
+    bitcoin::{get_blockchain, MemoryWallet},
     debug,
 };
 
@@ -25,7 +25,7 @@ pub async fn sign_psbt(
         debug!("tx:", base64::encode(&serialize(&tx.clone())));
         let blockchain = get_blockchain().await;
         blockchain.broadcast(&tx).await?;
-        synchronize_wallet(wallet).await?;
+
         let txid = tx.txid();
         let tx = blockchain
             .get_tx(&txid)

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -53,7 +53,7 @@ where
 pub async fn get_wallet(
     descriptor: &str,
     change_descriptor: Option<String>,
-) -> Result<Arc<Mutex<Wallet<MemoryDatabase>>>> {
+) -> Result<MemoryWallet> {
     let descriptor = descriptor.to_owned();
     let key = (descriptor.clone(), change_descriptor.clone());
 
@@ -103,6 +103,18 @@ pub async fn get_wallet(
 pub async fn get_blockchain() -> EsploraBlockchain {
     debug!("Getting blockchain");
     EsploraBlockchain::new(&BITCOIN_EXPLORER_API.read().await, 100)
+}
+
+pub async fn sync_wallet(wallet: &MemoryWallet) -> Result<()> {
+    let blockchain = get_blockchain().await;
+    wallet
+        .lock()
+        .await
+        .sync(&blockchain, SyncOptions::default())
+        .await?;
+
+    debug!("Wallet synced");
+    Ok(())
 }
 
 pub async fn sync_wallets() -> Result<()> {
@@ -162,6 +174,6 @@ pub async fn sync_wallets() -> Result<()> {
         }
     };
 
-    debug!("All synced");
+    debug!("All wallets synced");
     Ok(())
 }

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -54,7 +54,7 @@ where
 
 pub async fn get_wallet(
     descriptor: &SecretString,
-    change_descriptor: Option<SecretString>,
+    change_descriptor: Option<&SecretString>,
 ) -> Result<Arc<Mutex<Wallet<MemoryDatabase>>>> {
     let descriptor_key = format!("{descriptor:?}{change_descriptor:?}");
     let key = sha256::Hash::hash(descriptor_key.as_bytes()).to_string();
@@ -78,14 +78,9 @@ pub async fn get_wallet(
     }
     drop(wallets_lock);
 
-    let mut change_descriptor = None;
-    if let Some(desc) = change_descriptor {
-        change_descriptor = Some(desc);
-    };
-
     let new_wallet = Arc::new(Mutex::new(Wallet::new(
         &descriptor.0,
-        change_descriptor,
+        change_descriptor.map(|desc| &desc.0),
         network,
         MemoryDatabase::default(),
     )?));

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -26,7 +26,7 @@ use wallet::{
     psbt::{ProprietaryKeyDescriptor, ProprietaryKeyError, ProprietaryKeyLocation},
 };
 
-use crate::bitcoin::{get_wallet, synchronize_wallet};
+use crate::bitcoin::get_wallet;
 use crate::rgb::{constants::RGB_PSBT_TAPRET, structs::AddressAmount};
 
 #[allow(clippy::too_many_arguments)]
@@ -193,10 +193,6 @@ pub async fn estimate_fee_tx(
     let wallet = get_wallet(descriptor_pub, None)
         .await
         .expect("cannot retrieve wallet");
-
-    synchronize_wallet(&wallet)
-        .await
-        .expect("cannot sync wallet");
 
     let local = wallet.lock().await.get_utxo(outpoint);
     let local = local.expect("utxo not found").unwrap();

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -26,7 +26,7 @@ use wallet::{
     psbt::{ProprietaryKeyDescriptor, ProprietaryKeyError, ProprietaryKeyLocation},
 };
 
-use crate::bitcoin::get_wallet;
+use crate::bitcoin::{get_wallet, sync_wallet};
 use crate::rgb::{constants::RGB_PSBT_TAPRET, structs::AddressAmount};
 
 #[allow(clippy::too_many_arguments)]
@@ -193,6 +193,8 @@ pub async fn estimate_fee_tx(
     let wallet = get_wallet(descriptor_pub, None)
         .await
         .expect("cannot retrieve wallet");
+
+    sync_wallet(&wallet).await.expect("");
 
     let local = wallet.lock().await.get_utxo(outpoint);
     let local = local.expect("utxo not found").unwrap();

--- a/src/web.rs
+++ b/src/web.rs
@@ -190,8 +190,11 @@ pub mod bitcoin {
         set_panic_hook();
         future_to_promise(async move {
             let change_descriptor = change_descriptor.map(SecretString);
-            match crate::bitcoin::get_wallet_data(&SecretString(descriptor), change_descriptor)
-                .await
+            match crate::bitcoin::get_wallet_data(
+                &SecretString(descriptor),
+                change_descriptor.as_ref(),
+            )
+            .await
             {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),

--- a/src/web.rs
+++ b/src/web.rs
@@ -183,6 +183,20 @@ pub mod bitcoin {
     }
 
     #[wasm_bindgen]
+    pub fn sync_wallets() -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::bitcoin::sync_wallets().await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
     pub fn send_sats(
         descriptor: String,
         change_descriptor: String,

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -35,7 +35,7 @@ async fn payjoin() -> Result<()> {
 
     let wallet = get_wallet_data(
         &SecretString(vault.private.btc_descriptor_xprv.clone()),
-        Some(SecretString(
+        Some(&SecretString(
             vault.private.btc_change_descriptor_xprv.clone(),
         )),
     )

--- a/tests/rgb/integration/stress.rs
+++ b/tests/rgb/integration/stress.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, str::FromStr};
 use anyhow::Ok;
 use bitcoin::psbt::PartiallySignedTransaction;
 use bitmask_core::{
-    bitcoin::{get_wallet, save_mnemonic, sign_psbt, synchronize_wallet},
+    bitcoin::{get_wallet, save_mnemonic, sign_psbt, sync_wallet},
     rgb::{
         clear_stock, clear_watcher, constants::RGB_DEFAULT_NAME, create_watcher, list_contracts,
     },
@@ -152,7 +152,7 @@ async fn allow_issue_x_fungibles_witn_spend_utxos() -> anyhow::Result<()> {
     let final_psbt = PartiallySignedTransaction::from(original_psbt);
 
     let issuer_wallet = get_wallet(&issuer_keys.private.rgb_assets_descriptor_xprv, None).await?;
-    synchronize_wallet(&issuer_wallet).await?;
+    sync_wallet(&issuer_wallet).await?;
 
     let sign = sign_psbt(&issuer_wallet, final_psbt).await;
     assert!(sign.is_ok());
@@ -384,7 +384,7 @@ async fn allow_issue_x_uda_witn_spend_utxos() -> anyhow::Result<()> {
     let final_psbt = PartiallySignedTransaction::from(original_psbt);
 
     let issuer_wallet = get_wallet(&issuer_keys.private.rgb_udas_descriptor_xprv, None).await?;
-    synchronize_wallet(&issuer_wallet).await?;
+    sync_wallet(&issuer_wallet).await?;
 
     let sign = sign_psbt(&issuer_wallet, final_psbt).await;
     assert!(sign.is_ok());

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, env, process::Stdio};
 
 use bdk::wallet::AddressIndex;
 use bitmask_core::{
-    bitcoin::{get_wallet, get_wallet_data, save_mnemonic, synchronize_wallet},
+    bitcoin::{get_wallet, get_wallet_data, save_mnemonic, sync_wallet},
     rgb::{
         create_invoice, create_psbt, create_watcher, import, issue_contract, transfer_asset,
         watcher_details, watcher_next_address, watcher_next_utxo,
@@ -240,7 +240,7 @@ pub async fn create_new_invoice(
         .to_string();
 
     send_some_coins(owner_address, "0.1").await;
-    synchronize_wallet(&owner_vault).await?;
+    sync_wallet(&owner_vault).await?;
 
     let beneficiary_utxo = owner_vault.lock().await.list_unspent()?;
     let beneficiary_utxo = beneficiary_utxo.first().unwrap();

--- a/tests/rgb/integration/watcher.rs
+++ b/tests/rgb/integration/watcher.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 use bitmask_core::{
-    bitcoin::{get_wallet, save_mnemonic, synchronize_wallet},
+    bitcoin::{get_wallet, save_mnemonic, sync_wallet},
     rgb::{create_watcher, watcher_address, watcher_next_address, watcher_next_utxo, watcher_utxo},
     structs::WatcherRequest,
 };
@@ -24,7 +24,7 @@ async fn allow_monitoring_address() -> anyhow::Result<()> {
 
     // Get Address
     let issuer_wallet = get_wallet(&issuer_keys.private.btc_descriptor_xprv, None).await?;
-    synchronize_wallet(&issuer_wallet).await?;
+    sync_wallet(&issuer_wallet).await?;
 
     let address = issuer_wallet
         .lock()
@@ -55,7 +55,7 @@ async fn allow_monitoring_address_with_coins() -> anyhow::Result<()> {
 
     // Get Address
     let issuer_wallet = get_wallet(&issuer_keys.private.btc_descriptor_xprv, None).await?;
-    synchronize_wallet(&issuer_wallet).await?;
+    sync_wallet(&issuer_wallet).await?;
     let address = issuer_wallet
         .lock()
         .await

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -3,7 +3,6 @@ use std::env;
 
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::sync_wallets,
     bitcoin::{decrypt_wallet, encrypt_wallet, get_wallet_data, hash_password, new_wallet},
     constants::{get_network, switch_network},
     structs::SecretString,
@@ -117,21 +116,14 @@ async fn get_wallet_balance() -> Result<()> {
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash, &seed_password).await?;
     let main_vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
 
-    sync_wallets().await?;
-
-    let main_btc_wallet = get_wallet_data(
-        &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
-        None,
-    )
-    .await?;
-
     let btc_wallet = get_wallet_data(
         &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
         None,
     )
     .await?;
+
     warn!("Descriptor:", main_vault.private.btc_descriptor_xprv);
-    warn!("Address:", main_btc_wallet.address);
+    warn!("Address:", btc_wallet.address);
     warn!("Wallet Balance:", btc_wallet.balance.confirmed.to_string());
 
     Ok(())

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -4,7 +4,8 @@ use std::env;
 use anyhow::Result;
 use bitmask_core::{
     bitcoin::{
-        get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed, save_mnemonic_seed,
+        get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed,
+        save_mnemonic_seed, sync_wallets,
     },
     constants::{get_network, switch_network},
     util::init_logging,
@@ -99,6 +100,8 @@ async fn get_wallet_balance() -> Result<()> {
     let hash = hash_password(ENCRYPTION_PASSWORD);
     let main_mnemonic_data = save_mnemonic_seed(&main_mnemonic, &hash, SEED_PASSWORD).await?;
     let main_vault = get_encrypted_wallet(&hash, &main_mnemonic_data.encrypted_descriptors)?;
+
+    sync_wallets().await?;
 
     let main_btc_wallet = get_wallet_data(&main_vault.private.btc_descriptor_xprv, None).await?;
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -3,8 +3,8 @@ use std::env;
 
 use anyhow::Result;
 use bitmask_core::{
+    bitcoin::sync_wallets,
     bitcoin::{decrypt_wallet, encrypt_wallet, get_wallet_data, hash_password, new_wallet},
-    bitcoin::{get_wallet_data, hash_password, sync_wallets},
     constants::{get_network, switch_network},
     structs::SecretString,
     util::init_logging,

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -77,6 +77,8 @@ async fn import_and_open_wallet() {
         "expected xpubkh matches loaded wallet"
     );
 
+    resolve(sync_wallets()).await;
+
     info!("Get wallet data");
     let wallet_str: JsValue = resolve(get_wallet_data(
         DESCRIPTOR.to_owned(),
@@ -138,6 +140,9 @@ async fn import_test_wallet() {
     let encrypted_wallet_data: EncryptedWalletData = json_parse(&vault_str);
 
     info!("Get wallet data");
+
+    resolve(sync_wallets()).await;
+
     let wallet_str: JsValue = resolve(get_wallet_data(
         encrypted_wallet_data.private.btc_descriptor_xprv.clone(),
         Some(

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -5,7 +5,7 @@ use bitmask_core::{
     web::{
         bitcoin::{
             get_encrypted_wallet, get_wallet_data, hash_password, new_mnemonic_seed,
-            save_mnemonic_seed, send_sats,
+            save_mnemonic_seed, send_sats, sync_wallets,
         },
         json_parse, resolve, set_panic_hook, to_string,
     },

--- a/tests/web_wallet.rs
+++ b/tests/web_wallet.rs
@@ -82,8 +82,6 @@ async fn import_and_open_wallet() {
         "expected xpubkh matches loaded wallet"
     );
 
-    resolve(sync_wallets()).await;
-
     info!("Get wallet data");
     let wallet_str: JsValue = resolve(get_wallet_data(
         DESCRIPTOR.to_owned(),


### PR DESCRIPTION
Resolves #244 and #151 

Removes `synchronize_wallet`, and ntroduces two separate methods, `sync_wallet` and `sync_wallets`. The first is only for internal use, and can be passed a single wallet, whereas the second will sync all wallets and can be called from the browser side.

In the future we could add even more fine-grained wallet syncing for a specific descriptor hash, used as a key in #242 