### PR TITLE
Fix Payjoin: Add back original PSBT input to payjoin proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "payjoin"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5770c48c69af29fc8fa9f9ccddd9aee7daf2616ba196651913939671fdcf1f"
+checksum = "e076c820f8780985db6a2b1f6c0914350becc79aa3e071872bcd4bc17e7e0f06"
 dependencies = [
  "base64 0.13.1",
  "bip21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ miniscript_crate = { package = "miniscript", version = "9.0.1", features = [
 ] }
 nostr-sdk = "0.22.0"
 once_cell = "1.17.1"
-payjoin = { version = "0.7.0", features = ["sender"] }
+payjoin = { version = "0.8.0", features = ["send"] }
 percent-encoding = "2.2.0"
 postcard = { version = "1.0.4", features = ["alloc"] }
 pretty_env_logger = "0.5.0"


### PR DESCRIPTION
Unlike Bitcoin Core's walletprocesspsbt RPC, BDK's finalize_psbt only checks if the script in the PSBT input map matches the descriptor and does not check whether it has control of the OutPoint specified in the unsigned_tx's TxIn. BIP 78 spec clears script data from payjoin proposal. So the original_psbt input data needs to be added back into payjoin_psbt without overwriting receiver input.

See where [we ran into the same problem with BDK-CLI](https://github.com/bitcoindevkit/bdk-cli/pull/156#discussion_r1251172981) and [the proposed solution there](https://github.com/bitcoindevkit/bdk-cli/pull/156#discussion_r1261384934).