### PR TITLE
Add an RGB_LIB_IDs.toml file, and build script to auto-generate it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "rgb-contracts"
 version = "0.10.0-beta.2"
-source = "git+https://github.com/crisdut/rgb?branch=release/bmc-v0.6-rc6#04b7a3cce360489f2b2915d2e7bb3e645cae30eb"
+source = "git+https://github.com/crisdut/rgb?branch=release/bmc-v0.6-rc6#2f196efaa3f32bca6ee129ddb7be722c78975d2c"
 dependencies = [
  "amplify",
  "baid58",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.10.4"
-source = "git+https://github.com/crisdut/rgb-core?branch=release/bmc-v0.6-rc6#7d983e19fabe01261d866a379cde91ac02ae2782"
+source = "git+https://github.com/crisdut/rgb-core?branch=release/bmc-v0.6-rc6#5fa9b746b30706986eb75f5b86f1ee5bc5ff3971"
 dependencies = [
  "aluvm",
  "amplify",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.10.2"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc6#868e287531f4f2d8870acf029f6b3a4a6df82c57"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc6#0484bb6d0932830e05b87840422552927104b497"
 dependencies = [
  "amplify",
  "baid58",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "rgb-wallet"
 version = "0.10.2"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc6#868e287531f4f2d8870acf029f6b3a4a6df82c57"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc6#0484bb6d0932830e05b87840422552927104b497"
 dependencies = [
  "amplify",
  "baid58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "strict_encoding",
  "strict_types",
  "tokio",
+ "toml 0.7.6",
  "tower-http",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3516,6 +3517,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,9 +2264,9 @@ checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "payjoin"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5770c48c69af29fc8fa9f9ccddd9aee7daf2616ba196651913939671fdcf1f"
+checksum = "e076c820f8780985db6a2b1f6c0914350becc79aa3e071872bcd4bc17e7e0f06"
 dependencies = [
  "base64 0.13.1",
  "bip21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ miniscript_crate = { package = "miniscript", version = "9.0.1", features = [
 ] }
 nostr-sdk = "0.22.0"
 once_cell = "1.17.1"
-payjoin = { version = "0.7.0", features = ["sender"] }
+payjoin = { version = "0.8.0", features = ["send"] }
 percent-encoding = "2.2.0"
 postcard = { version = "1.0.4", features = ["alloc"] }
 pretty_env_logger = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,12 @@ tokio = { version = "1.28.2", features = ["full"] }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.36"
 
+[build-dependencies]
+anyhow = "1.0.71"
+rgb-std = { version = "0.10.2" }
+serde = "1.0.164"
+toml = { version = "0.7.5", features = ["preserve_order"] }
+
 [patch.crates-io]
 # TODO: Remove this after support amplify 4.x (custom)
 bitcoin_scripts = { git = "https://github.com/crisdut/bp-foundation", branch = "release/0.10.0-alpha.2" }

--- a/RGB_LIB_IDs.toml
+++ b/RGB_LIB_IDs.toml
@@ -1,5 +1,8 @@
 # Auto-generated semantic IDs for RGB consensus-critical libraries and their corresponding versions of bitmask-core.
 
+[LIB_ID_RGB]
+memphis_asia_crash_4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V = "0.6.0-rc.6"
+
 [LIB_ID_RGB20]
 dragon_table_game_GVz4mvYE94aQ9q2HPtV9VuoppcDdduP54BMKffF7YoFH = "0.6.0-rc.6"
 

--- a/RGB_LIB_IDs.toml
+++ b/RGB_LIB_IDs.toml
@@ -1,0 +1,16 @@
+# Auto-generated semantic IDs for RGB consensus-critical libraries and their corresponding versions of bitmask-core.
+
+[LIB_ID_RGB20]
+dragon_table_game_GVz4mvYE94aQ9q2HPtV9VuoppcDdduP54BMKffF7YoFH = "0.6.0-rc.6"
+
+[LIB_ID_RGB21]
+benny_horse_salad_E3AsDKsHSqAPQLvJke3DcPrkErbS2Jxf8pQ8jYBQYJPA = "0.6.0-rc.6"
+
+[LIB_ID_RGB25]
+ritual_mask_next_4JmGrg7oTgwuCQtyC4ezC38ToHMzgMCVS5kMSDPwo2ee = "0.6.0-rc.6"
+
+[LIB_ID_RGB_CONTRACT]
+price_canvas_oliver_9Te5P6nq3oaDHMgttLEbkojbeQPTqqZLhjxZ3my1F8aJ = "0.6.0-rc.6"
+
+[LIB_ID_RGB_STD]
+patent_iris_torch_Firwvn75qng8cm4n7iHXXiFDsG1V476vYGqdfwwFRT1b = "0.6.0-rc.6"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,61 @@
+use std::{collections::BTreeMap, fs};
+
+use anyhow::Result;
+use rgbstd::{
+    interface::{LIB_ID_RGB20, LIB_ID_RGB21, LIB_ID_RGB25},
+    stl::{LIB_ID_RGB_CONTRACT, LIB_ID_RGB_STD},
+};
+use serde::{Deserialize, Serialize};
+
+type IdVersionMap = BTreeMap<String, String>;
+
+#[allow(non_snake_case)]
+#[derive(Deserialize, Serialize)]
+struct LibIds {
+    LIB_ID_RGB20: IdVersionMap,
+    LIB_ID_RGB21: IdVersionMap,
+    LIB_ID_RGB25: IdVersionMap,
+    LIB_ID_RGB_CONTRACT: IdVersionMap,
+    LIB_ID_RGB_STD: IdVersionMap,
+}
+
+const LIB_IDS_FILE: &str = "RGB_LIB_IDs.toml";
+const NOTE_COMMENT: &str =
+    "# Auto-generated semantic IDs for RGB consensus-critical libraries and their corresponding versions of bitmask-core.\n\n";
+
+fn main() -> Result<()> {
+    const BMC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    let lib_ids_file = fs::read_to_string(LIB_IDS_FILE)?;
+    let mut lib_ids: LibIds = toml::from_str(&lib_ids_file)?;
+
+    lib_ids
+        .LIB_ID_RGB20
+        .entry(LIB_ID_RGB20.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
+
+    lib_ids
+        .LIB_ID_RGB21
+        .entry(LIB_ID_RGB21.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
+
+    lib_ids
+        .LIB_ID_RGB25
+        .entry(LIB_ID_RGB25.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
+
+    lib_ids
+        .LIB_ID_RGB_CONTRACT
+        .entry(LIB_ID_RGB_CONTRACT.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
+
+    lib_ids
+        .LIB_ID_RGB_STD
+        .entry(LIB_ID_RGB_STD.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
+
+    let toml = toml::to_string(&lib_ids)?;
+    fs::write(LIB_IDS_FILE, format!("{NOTE_COMMENT}{toml}"))?;
+
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fs};
 use anyhow::Result;
 use rgbstd::{
     interface::{LIB_ID_RGB20, LIB_ID_RGB21, LIB_ID_RGB25},
-    stl::{LIB_ID_RGB_CONTRACT, LIB_ID_RGB_STD},
+    stl::{LIB_ID_RGB, LIB_ID_RGB_CONTRACT, LIB_ID_RGB_STD},
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +12,7 @@ type IdVersionMap = BTreeMap<String, String>;
 #[allow(non_snake_case)]
 #[derive(Deserialize, Serialize)]
 struct LibIds {
+    LIB_ID_RGB: IdVersionMap,
     LIB_ID_RGB20: IdVersionMap,
     LIB_ID_RGB21: IdVersionMap,
     LIB_ID_RGB25: IdVersionMap,
@@ -28,6 +29,11 @@ fn main() -> Result<()> {
 
     let lib_ids_file = fs::read_to_string(LIB_IDS_FILE)?;
     let mut lib_ids: LibIds = toml::from_str(&lib_ids_file)?;
+
+    lib_ids
+        .LIB_ID_RGB
+        .entry(LIB_ID_RGB.to_owned())
+        .or_insert(BMC_VERSION.to_owned());
 
     lib_ids
         .LIB_ID_RGB20

--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use bdk::{wallet::tx_builder::TxOrdering, FeeRate, TransactionDetails};
 use bitcoin::consensus::serialize;
+use payjoin::send::Configuration;
 use payjoin::{PjUri, PjUriExt};
 
 use crate::{
@@ -58,7 +59,7 @@ pub async fn create_payjoin(
     info!("Original PSBT successfully signed");
 
     // TODO use fee_rate
-    let pj_params = payjoin::sender::Configuration::non_incentivizing();
+    let pj_params = Configuration::non_incentivizing();
     let (req, ctx) = pj_uri.create_pj_request(original_psbt, pj_params)?;
     info!("Built PayJoin request");
     let response = reqwest::Client::new()

--- a/tests/rgb/unit/stl.rs
+++ b/tests/rgb/unit/stl.rs
@@ -7,35 +7,35 @@ use rgbstd::{
 
 #[tokio::test]
 async fn check_rgb20_stl() -> Result<()> {
-    let shema = rgb20_stl();
-    assert_eq!(LIB_ID_RGB20, shema.id().to_string());
+    let schema = rgb20_stl();
+    assert_eq!(LIB_ID_RGB20, schema.id().to_string());
     Ok(())
 }
 
 #[tokio::test]
 async fn check_rgb21_stl() -> Result<()> {
-    let shema = rgb21_stl();
-    assert_eq!(LIB_ID_RGB21, shema.id().to_string());
+    let schema = rgb21_stl();
+    assert_eq!(LIB_ID_RGB21, schema.id().to_string());
     Ok(())
 }
 
 #[tokio::test]
 async fn check_rgb25_stl() -> Result<()> {
-    let shema = rgb25_stl();
-    assert_eq!(LIB_ID_RGB25, shema.id().to_string());
+    let schema = rgb25_stl();
+    assert_eq!(LIB_ID_RGB25, schema.id().to_string());
     Ok(())
 }
 
 #[tokio::test]
 async fn check_rgbstd_stl() -> Result<()> {
-    let shema = rgb_std_stl();
-    assert_eq!(LIB_ID_RGB_STD, shema.id().to_string());
+    let schema = rgb_std_stl();
+    assert_eq!(LIB_ID_RGB_STD, schema.id().to_string());
     Ok(())
 }
 
 #[tokio::test]
 async fn check_rgbcontract_stl() -> Result<()> {
-    let shema = rgb_contract_stl();
-    assert_eq!(LIB_ID_RGB_CONTRACT, shema.id().to_string());
+    let schema = rgb_contract_stl();
+    assert_eq!(LIB_ID_RGB_CONTRACT, schema.id().to_string());
     Ok(())
 }

--- a/tests/rgb/web/stl_ids.rs
+++ b/tests/rgb/web/stl_ids.rs
@@ -10,30 +10,30 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 async fn check_rgb20_stl() {
-    let shema = rgb20_stl();
-    assert_eq!(LIB_ID_RGB20, shema.id().to_string());
+    let schema = rgb20_stl();
+    assert_eq!(LIB_ID_RGB20, schema.id().to_string());
 }
 
 #[wasm_bindgen_test]
 async fn check_rgb21_stl() {
-    let shema = rgb21_stl();
-    assert_eq!(LIB_ID_RGB21, shema.id().to_string());
+    let schema = rgb21_stl();
+    assert_eq!(LIB_ID_RGB21, schema.id().to_string());
 }
 
 #[wasm_bindgen_test]
 async fn check_rgb25_stl() {
-    let shema = rgb25_stl();
-    assert_eq!(LIB_ID_RGB25, shema.id().to_string());
+    let schema = rgb25_stl();
+    assert_eq!(LIB_ID_RGB25, schema.id().to_string());
 }
 
 #[wasm_bindgen_test]
 async fn check_rgbstd_stl() {
-    let shema = rgb_std_stl();
-    assert_eq!(LIB_ID_RGB_STD, shema.id().to_string());
+    let schema = rgb_std_stl();
+    assert_eq!(LIB_ID_RGB_STD, schema.id().to_string());
 }
 
 #[wasm_bindgen_test]
 async fn check_rgbcontract_stl() {
-    let shema = rgb_contract_stl();
-    assert_eq!(LIB_ID_RGB_CONTRACT, shema.id().to_string());
+    let schema = rgb_contract_stl();
+    assert_eq!(LIB_ID_RGB_CONTRACT, schema.id().to_string());
 }


### PR DESCRIPTION
This helps us associate RGB semantic IDs to help us track consensus-breaking changes.