### PR TITLE
Clamp payjoin fee if recommendation unavailable

### DIFF
--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -91,10 +91,11 @@ pub async fn create_payjoin(
             let recommended_fee = Amount::from_sat(enacted_fee_rate.fee_wu(P2TR_INPUT_WEIGHT));
             let max_additional_fee = std::cmp::min(
                 recommended_fee,
-                amount_available, // offer amount available if recommendation is not
+                amount_available, // "clamp" to amount available if recommendation is not
             );
 
             Configuration::with_fee_contribution(max_additional_fee, Some(index))
+                .clamp_fee_contribution(true);
         }
         None => Configuration::non_incentivizing(),
     };


### PR DESCRIPTION
Otherwise `create_pj_request` would fail in the clamped path.

This piece of code should also enforce min_fee_rate_sat_per_vb BUT that method only accepts u64 when it should accept f32 and will have to wait for the corresponding PDK update. Such an update might look like this

```rs
let recommended_fee = Amount::from_sat(enacted_fee_rate.fee_wu(P2TR_INPUT_WEIGHT));
let max_additional_fee = std::cmp::min(
    recommended_fee,
    amount_available, // "clamp" to amount available if recommendation is not
);

let config = Configuration::with_fee_contribution(max_additional_fee, Some(index));

if max_additional_fee == recommended_fee {
    // require sender to maintain a minimum fee rate since we're paying for it
    config.min_fee_rate_sat_per_vb(enacted_fee_rate.as_sat_per_vb());
} else {
    // allow create_pj_request to submit fee less than recommendation
    config.clamp_fee_contribution(true);
}
config
```