### PR TITLE
Add LIB_ID_RGB to version stock

### DIFF
--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -91,10 +91,11 @@ pub async fn create_payjoin(
             let recommended_fee = Amount::from_sat(enacted_fee_rate.fee_wu(P2TR_INPUT_WEIGHT));
             let max_additional_fee = std::cmp::min(
                 recommended_fee,
-                amount_available, // offer amount available if recommendation is not
+                amount_available, // "clamp" to amount available if recommendation is not
             );
 
             Configuration::with_fee_contribution(max_additional_fee, Some(index))
+                .clamp_fee_contribution(true);
         }
         None => Configuration::non_incentivizing(),
     };

--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -95,7 +95,7 @@ pub async fn create_payjoin(
             );
 
             Configuration::with_fee_contribution(max_additional_fee, Some(index))
-                .clamp_fee_contribution(true);
+                .clamp_fee_contribution(true)
         }
         None => Configuration::non_incentivizing(),
     };

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -1,7 +1,7 @@
 use amplify::confinement::{Confined, U32};
 use anyhow::Result;
 use postcard::{from_bytes, to_allocvec};
-use rgbstd::persistence::Stock;
+use rgbstd::{persistence::Stock, stl::LIB_ID_RGB};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::{
@@ -13,7 +13,7 @@ pub async fn store_stock(sk: &str, name: &str, stock: &Stock) -> Result<()> {
     let data = stock.to_strict_serialized::<U32>()?;
     store(
         sk,
-        name,
+        &format!("{name}/{LIB_ID_RGB}"),
         &data,
         false,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -25,7 +25,7 @@ pub async fn force_store_stock(sk: &str, name: &str, stock: &Stock) -> Result<()
     let data = stock.to_strict_serialized::<U32>()?;
     store(
         sk,
-        name,
+        &format!("{name}/{LIB_ID_RGB}"),
         &data,
         true,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -34,7 +34,9 @@ pub async fn force_store_stock(sk: &str, name: &str, stock: &Stock) -> Result<()
 }
 
 pub async fn retrieve_stock(sk: &str, name: &str) -> Result<Stock> {
-    let (data, _) = retrieve(sk, name).await.unwrap_or_default();
+    let (data, _) = retrieve(sk, &format!("{name}/{LIB_ID_RGB}"))
+        .await
+        .unwrap_or_default();
     if data.is_empty() {
         Ok(Stock::default())
     } else {
@@ -49,7 +51,7 @@ pub async fn store_wallets(sk: &str, name: &str, rgb_wallets: &RgbAccount) -> Re
     let data = to_allocvec(rgb_wallets)?;
     store(
         sk,
-        name,
+        &format!("{name}/{LIB_ID_RGB}"),
         &data,
         false,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -58,7 +60,9 @@ pub async fn store_wallets(sk: &str, name: &str, rgb_wallets: &RgbAccount) -> Re
 }
 
 pub async fn retrieve_wallets(sk: &str, name: &str) -> Result<RgbAccount> {
-    let (data, _) = retrieve(sk, name).await.unwrap_or_default();
+    let (data, _) = retrieve(sk, &format!("{name}/{LIB_ID_RGB}"))
+        .await
+        .unwrap_or_default();
     if data.is_empty() {
         Ok(RgbAccount::default())
     } else {


### PR DESCRIPTION
Two questions for you, @crisdut:

1. I'm not sure why I get this error in `carbonado.rs`:
```
unresolved import `rgbstd::stl::LIB_ID_RGB`
no `LIB_ID_RGB` in `stl`
```
2. I'm not sure if we also need to do versioning in the rgb_wallets, and what consequence this could have. It would be nice to keep a list of old contracts, but if we don't have the data for them, that could probably cause a panic, so that will need to be tested and handled.