### PR TITLE
Reproducible Docker Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 .dockerignore
 .git
 .gitignore
+rust-toolchain.toml

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM rust:slim-buster AS builder
+FROM rust:1.70-slim-buster AS builder
 ARG BUILDER_DIR=/srv/bitmask
 ARG BUILDER_SRC=/opt/src/bitmask
 
@@ -13,7 +13,7 @@ COPY . .
 RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
 # Runtime
-FROM rust:slim-buster AS runtime
+FROM rust:1.70-slim-buster AS runtime
 
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin

--- a/docker/bitmask/Dockerfile.ST120
+++ b/docker/bitmask/Dockerfile.ST120
@@ -1,5 +1,5 @@
 # Builder
-FROM rust:slim-buster AS builder
+FROM rust:1.69-slim-buster AS builder
 ARG BUILDER_DIR=/srv/bitmask
 ARG BUILDER_SRC=/opt/src/bitmask
 ARG SOURCE_CODE=https://github.com/diba-io/bitmask-core.git
@@ -12,10 +12,11 @@ WORKDIR $BUILDER_DIR
 WORKDIR $BUILDER_SRC
 RUN git clone $SOURCE_CODE $BUILDER_SRC
 RUN git checkout $VERSION
+RUN rm rust-toolchain.toml
 RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
 # Runtime
-FROM rust:slim-buster AS runtime
+FROM rust:1.69-slim-buster AS runtime
 
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin


### PR DESCRIPTION
@rustchain64 found a strange behavior when try build docker images.

For some reason, some dependencies crashes in docker, but not in host machine. For example:

```
Compiling miniscript v9.0.1
#0 142.8  Compiling sha1 v0.10.5
#0 142.9 error[E0275]: overflow evaluating the requirement `F: FnMut<(&Pk,)>`
#0 142.9  |
#0 142.9  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`miniscript`)
#0 142.9  = note: required for `&mut F` to implement `FnMut<(&Pk,)>`
``` 

After investigate, we found that:

https://github.com/rust-lang/rust/issues/110656


This PR intent to introduce "reproducible docker build", is similar to reproducible builds strategy. I would like to ensure that the rust image version is always the same, without being changed by toolchain.toml. In this way we avoid this type of error.


