### PR TITLE
Reduce Esplora stop-gap from 100 to 1

### DIFF
--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -107,7 +107,7 @@ pub async fn get_wallet(
 
 pub async fn get_blockchain() -> EsploraBlockchain {
     debug!("Getting blockchain");
-    EsploraBlockchain::new(&BITCOIN_EXPLORER_API.read().await, 100)
+    EsploraBlockchain::new(&BITCOIN_EXPLORER_API.read().await, 1)
 }
 
 pub async fn sync_wallet(wallet: &MemoryWallet) -> Result<()> {

--- a/src/rgb/prefetch.rs
+++ b/src/rgb/prefetch.rs
@@ -93,7 +93,7 @@ pub async fn prefetch_resolver_rgb(
     use crate::rgb::import::contract_from_genesis;
 
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
     let serialized = if contract.starts_with("rgb1") {
         let (_, serialized, _) =
             decode(contract).expect("invalid serialized contract (bech32m format)");
@@ -170,7 +170,7 @@ pub async fn prefetch_resolver_import_rgb(
     use rgbstd::contract::Genesis;
 
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
     let serialized = if contract.starts_with("rgb1") {
         let (_, serialized, _) =
             decode(contract).expect("invalid serialized contract (bech32m format)");
@@ -235,7 +235,7 @@ pub async fn prefetch_resolver_import_rgb(
 #[cfg(target_arch = "wasm32")]
 pub async fn prefetch_resolver_psbt(input_utxo: &str, explorer: &mut ExplorerResolver) {
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
 
     let outpoint: OutPoint = input_utxo.parse().expect("invalid outpoint format");
     let txid = outpoint.txid;
@@ -255,7 +255,7 @@ pub async fn prefetch_resolver_utxo_status(
     explorer: &mut ExplorerResolver,
 ) {
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
     let utxos: Vec<Utxo> = wallet
         .utxos
         .clone()
@@ -292,7 +292,7 @@ pub async fn prefetch_resolver_utxos(
     use std::collections::HashSet;
 
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
 
     let step = 100;
     let index = 0;
@@ -375,7 +375,7 @@ pub async fn prefetch_resolver_utxos(
 
 #[cfg(target_arch = "wasm32")]
 pub async fn prefetch_resolver_txs(txids: Vec<Txid>, explorer: &mut ExplorerResolver) {
-    let esplora_client = EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+    let esplora_client = EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
     for txid in txids {
         if let Some(tx) = esplora_client
             .get_tx(&txid)
@@ -395,7 +395,7 @@ pub async fn prefetch_resolver_waddress(
     limit: Option<u32>,
 ) {
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
 
     let mut step = 100;
     if let Some(limit) = limit {
@@ -474,7 +474,7 @@ pub async fn prefetch_resolver_wutxo(
     limit: Option<u32>,
 ) {
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
 
     let outpoint = OutPoint::from_str(utxo).expect("invalid outpoint");
 
@@ -498,7 +498,7 @@ pub async fn prefetch_resolver_tx_height(txid: rgbstd::Txid, explorer: &mut Expl
     use rgbstd::contract::{WitnessHeight, WitnessOrd};
 
     let esplora_client: EsploraBlockchain =
-        EsploraBlockchain::new(&explorer.explorer_url, 100).with_concurrency(6);
+        EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
 
     let transaction_id =
         &bitcoin::Txid::from_str(&txid.to_hex()).expect("invalid transaction id parse");

--- a/src/rgb/resolvers.rs
+++ b/src/rgb/resolvers.rs
@@ -42,6 +42,7 @@ impl rgb::Resolver for ExplorerResolver {
             .build_blocking()
             .expect("service unavaliable");
         // TODO: Remove that after bitcoin v.30 full compatibility
+
         let script_list = scripts
             .into_iter()
             .map(|(d, sc)| {

--- a/tests/rgb/integration/dustless.rs
+++ b/tests/rgb/integration/dustless.rs
@@ -65,7 +65,7 @@ async fn allow_multiple_inputs_in_same_psbt() -> anyhow::Result<()> {
     let issuer_address = &issuer_vault
         .lock()
         .await
-        .get_address(AddressIndex::Peek(0))?
+        .get_address(AddressIndex::LastUnused)?
         .address
         .to_string();
 

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -270,7 +270,7 @@ pub async fn create_new_invoice(
     let owner_address = &owner_vault
         .lock()
         .await
-        .get_address(AddressIndex::Peek(0))?
+        .get_address(AddressIndex::LastUnused)?
         .address;
 
     send_some_coins(&owner_address.to_string(), "0.1").await;


### PR DESCRIPTION
I see no reason we shouldn't do this, considering it'd be outside the wallet's nominal operation to have it any higher.