### PR TITLE
Hashed Name with Alternative Name Checks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -86,8 +86,8 @@ fn main() -> Result<()> {
     let toml = fs::read_to_string(FILE_HASHES_FILE)?;
     let mut doc: FileHashes = toml::from_str(&toml)?;
 
-    let assets_stock_name = format!("{NETWORK}-{LIB_ID_RGB}-{ASSETS_STOCK}");
-    let assets_wallets_name = format!("{NETWORK}-{LIB_ID_RGB}-{ASSETS_WALLETS}");
+    let assets_stock_name = format!("{LIB_ID_RGB}-{ASSETS_STOCK}");
+    let assets_wallets_name = format!("{LIB_ID_RGB}-{ASSETS_WALLETS}");
 
     let assets_stock_hash = blake3::hash(assets_stock_name.as_bytes())
         .to_hex()
@@ -97,11 +97,11 @@ fn main() -> Result<()> {
         .to_ascii_lowercase();
 
     doc.ASSETS_STOCK
-        .entry(assets_stock_hash)
+        .entry(format!("{}-{}", NETWORK, assets_stock_hash))
         .or_insert(assets_stock_name);
 
     doc.ASSETS_WALLETS
-        .entry(assets_wallets_hash)
+        .entry(format!("{}-{}", NETWORK, assets_wallets_hash))
         .or_insert(assets_wallets_name);
 
     let toml = toml::to_string(&doc)?;

--- a/build.rs
+++ b/build.rs
@@ -97,11 +97,11 @@ fn main() -> Result<()> {
         .to_ascii_lowercase();
 
     doc.ASSETS_STOCK
-        .entry(format!("{}-{}", NETWORK, assets_stock_hash))
+        .entry(format!("{NETWORK}-{assets_stock_hash}"))
         .or_insert(assets_stock_name);
 
     doc.ASSETS_WALLETS
-        .entry(format!("{}-{}", NETWORK, assets_wallets_hash))
+        .entry(format!("{NETWORK}-{assets_wallets_hash}"))
         .or_insert(assets_wallets_name);
 
     let toml = toml::to_string(&doc)?;

--- a/build.rs
+++ b/build.rs
@@ -97,11 +97,11 @@ fn main() -> Result<()> {
         .to_ascii_lowercase();
 
     doc.ASSETS_STOCK
-        .entry(format!("{NETWORK}-{assets_stock_hash}"))
+        .entry(format!("{NETWORK}-{assets_stock_hash}.c15"))
         .or_insert(assets_stock_name);
 
     doc.ASSETS_WALLETS
-        .entry(format!("{NETWORK}-{assets_wallets_hash}"))
+        .entry(format!("{NETWORK}-{assets_wallets_hash}.c15"))
         .or_insert(assets_wallets_name);
 
     let toml = toml::to_string(&doc)?;

--- a/file_hashes.toml
+++ b/file_hashes.toml
@@ -1,5 +1,5 @@
 [ASSETS_STOCK]
-7e9bb3bc108f2c3a3dc459f44a394db9e4071f0d61de07ece77f6145304b7630 = "bitcoin-urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_stock.c15"
+bitcoin-4b1bc93ea7f03c49c4424b56561c9c7437e5f16e5714cece615a48e249264a84 = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_stock.c15"
 
 [ASSETS_WALLETS]
-09b66ce867c9b9bd8ced2a15b112a83c753be611319c06b764a445e2c490ea15 = "bitcoin-urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_wallets.c15"
+bitcoin-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3 = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_wallets.c15"

--- a/file_hashes.toml
+++ b/file_hashes.toml
@@ -1,5 +1,5 @@
 [ASSETS_STOCK]
-bitcoin-4b1bc93ea7f03c49c4424b56561c9c7437e5f16e5714cece615a48e249264a84 = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_stock.c15"
+"bitcoin-4b1bc93ea7f03c49c4424b56561c9c7437e5f16e5714cece615a48e249264a84.c15" = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_stock.c15"
 
 [ASSETS_WALLETS]
-bitcoin-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3 = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_wallets.c15"
+"bitcoin-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15" = "urn:ubideco:stl:4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V#saturn-flash-emerald-bitmask-fungible_assets_wallets.c15"

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -6,10 +6,7 @@ use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::{
     carbonado::{retrieve, store},
-    rgb::{
-        constants::{OLD_LIB_ID_RGB, RGB_STRICT_TYPE_VERSION},
-        structs::RgbAccount,
-    },
+    rgb::{constants::RGB_STRICT_TYPE_VERSION, structs::RgbAccount},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
@@ -70,13 +67,9 @@ pub async fn retrieve_stock(sk: &str, name: &str) -> Result<Stock, StorageError>
         .to_hex()
         .to_lowercase();
 
-    let (data, _) = retrieve(
-        sk,
-        &format!("{hashed_name}.c15"),
-        vec![&name.to_string(), &format!("{OLD_LIB_ID_RGB}-{name}")],
-    )
-    .await
-    .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
+    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
 
     if data.is_empty() {
         Ok(Stock::default())
@@ -118,13 +111,9 @@ pub async fn retrieve_wallets(sk: &str, name: &str) -> Result<RgbAccount, Storag
         .to_hex()
         .to_lowercase();
 
-    let (data, _) = retrieve(
-        sk,
-        &format!("{hashed_name}.c15"),
-        vec![&name.to_string(), &format!("{OLD_LIB_ID_RGB}-{name}")],
-    )
-    .await
-    .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
+    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
 
     if data.is_empty() {
         Ok(RgbAccount::default())

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -6,7 +6,10 @@ use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::{
     carbonado::{retrieve, store},
-    rgb::{constants::RGB_STRICT_TYPE_VERSION, structs::RgbAccount},
+    rgb::{
+        constants::{OLD_LIB_ID_RGB, RGB_STRICT_TYPE_VERSION},
+        structs::RgbAccount,
+    },
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
@@ -27,9 +30,13 @@ pub async fn store_stock(sk: &str, name: &str, stock: &Stock) -> Result<(), Stor
         .to_strict_serialized::<U32>()
         .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
 
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
     store(
         sk,
-        &format!("{LIB_ID_RGB}-{name}"),
+        &format!("{hashed_name}.c15"),
         &data,
         false,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -43,9 +50,13 @@ pub async fn force_store_stock(sk: &str, name: &str, stock: &Stock) -> Result<()
         .to_strict_serialized::<U32>()
         .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
 
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
     store(
         sk,
-        &format!("{LIB_ID_RGB}-{name}"),
+        &hashed_name,
         &data,
         true,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -55,10 +66,14 @@ pub async fn force_store_stock(sk: &str, name: &str, stock: &Stock) -> Result<()
 }
 
 pub async fn retrieve_stock(sk: &str, name: &str) -> Result<Stock, StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
     let (data, _) = retrieve(
         sk,
-        &format!("{LIB_ID_RGB}-{name}"),
-        vec![&name.to_string(), &format!("{LIB_ID_RGB}-{name}")],
+        &format!("{hashed_name}.c15"),
+        vec![&name.to_string(), &format!("{OLD_LIB_ID_RGB}-{name}")],
     )
     .await
     .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
@@ -83,9 +98,13 @@ pub async fn store_wallets(
     let data = to_allocvec(rgb_wallets)
         .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
 
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
     store(
         sk,
-        &format!("{LIB_ID_RGB}-{name}"),
+        &format!("{hashed_name}.c15"),
         &data,
         false,
         Some(RGB_STRICT_TYPE_VERSION.to_vec()),
@@ -95,10 +114,14 @@ pub async fn store_wallets(
 }
 
 pub async fn retrieve_wallets(sk: &str, name: &str) -> Result<RgbAccount, StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
     let (data, _) = retrieve(
         sk,
-        &format!("{LIB_ID_RGB}-{name}"),
-        vec![&name.to_string(), &format!("{LIB_ID_RGB}-{name}")],
+        &format!("{hashed_name}.c15"),
+        vec![&name.to_string(), &format!("{OLD_LIB_ID_RGB}-{name}")],
     )
     .await
     .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;

--- a/src/rgb/constants.rs
+++ b/src/rgb/constants.rs
@@ -6,6 +6,9 @@ pub const RGB_DEFAULT_NAME: &str = "default";
 pub const RGB_OLDEST_VERSION: [u8; 8] = [0; 8];
 pub const RGB_STRICT_TYPE_VERSION: [u8; 8] = *b"rgbst160";
 
+// Latest RGB ID before UBIDECO semantic ID changes
+pub const OLD_LIB_ID_RGB: &str = "memphis_asia_crash_4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V";
+
 // General Errors
 #[cfg(target_arch = "wasm32")]
 pub const CARBONADO_UNAVALIABLE: &str = "carbonado filesystem";

--- a/src/rgb/constants.rs
+++ b/src/rgb/constants.rs
@@ -6,9 +6,6 @@ pub const RGB_DEFAULT_NAME: &str = "default";
 pub const RGB_OLDEST_VERSION: [u8; 8] = [0; 8];
 pub const RGB_STRICT_TYPE_VERSION: [u8; 8] = *b"rgbst160";
 
-// Latest RGB ID before UBIDECO semantic ID changes
-pub const OLD_LIB_ID_RGB: &str = "memphis_asia_crash_4fGZWR5mH5zZzRZ1r7CSRe776zm3hLBUngfXc4s3vm3V";
-
 // General Errors
 #[cfg(target_arch = "wasm32")]
 pub const CARBONADO_UNAVALIABLE: &str = "carbonado filesystem";


### PR DESCRIPTION
**Description**

I moved hashed to `rgb/carbonado.rs` to guarantees always we retrieve and stock with correct file name. Also, we maintain the alternative name check in retrieve operations (see details #279 and #289).