### PR TITLE
WIP/Docker test volumes

### DIFF
--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -1,5 +1,5 @@
-# Builder
-FROM rust:1.70-slim-buster AS builder
+#Buildere
+FROM rust:1.69-slim-buster AS builder
 ARG BUILDER_DIR=/srv/bitmask
 ARG BUILDER_SRC=/opt/src/bitmask
 
@@ -12,12 +12,15 @@ COPY . .
 
 RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
+# Set the working directory inside the container
+#WORKDIR /app
+
 # Runtime
-FROM rust:1.70-slim-buster AS runtime
+FROM rust:1.69-slim-buster AS runtime
 
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin
-ARG DATA_DIR=/data
+ARG DATA_DIR=/data/bitmaskd/carbonado/
 ARG USER=bitmask
 
 RUN apt-get update -y && apt-get install -y iputils-ping telnet \
@@ -30,11 +33,10 @@ COPY --from=builder --chown=${USER}:${USER} \
      "${BUILDER_DIR}/bin/" "${BIN_DIR}"
 
 USER ${USER}
-RUN chown -R bitmask:bitmask /data
-
-VOLUME /_data
+VOLUME ${DATA_DIR}
 EXPOSE 7070
 
+# Set the data directory for data persistence
 WORKDIR ${BIN_DIR}
 
 ENTRYPOINT ["bitmaskd"]

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -17,7 +17,9 @@ FROM rust:1.70-slim-buster AS runtime
 
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin
-ARG DATA_DIR=/tmp/bitmaskd/carbonado/
+#ARG BIN_DIR=/app .... this didn;t work bitmaskd not found
+#ARG DATA_DIR=/tmp/bitmaskd/carbonado/
+ARG DATA_DIR=/data
 ARG USER=bitmask
 
 RUN apt-get update -y && apt-get install -y iputils-ping telnet \
@@ -30,7 +32,9 @@ COPY --from=builder --chown=${USER}:${USER} \
      "${BUILDER_DIR}/bin/" "${BIN_DIR}"
 
 USER ${USER}
-VOLUME ${DATA_DIR}
+RUN chown -R bitmask:bitmask /data
+
+VOLUME /_data
 EXPOSE 7070
 
 WORKDIR ${BIN_DIR}

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -17,8 +17,6 @@ FROM rust:1.70-slim-buster AS runtime
 
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin
-#ARG BIN_DIR=/app .... this didn;t work bitmaskd not found
-#ARG DATA_DIR=/tmp/bitmaskd/carbonado/
 ARG DATA_DIR=/data
 ARG USER=bitmask
 

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -12,8 +12,7 @@ COPY . .
 
 RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
-# Set the working directory inside the container
-#WORKDIR /app
+ENV CARBONADO_DIR= "/data/bitmaskd/carbonado/"
 
 # Runtime
 FROM rust:1.69-slim-buster AS runtime

--- a/docker/bitmask/Dockerfile
+++ b/docker/bitmask/Dockerfile
@@ -1,4 +1,4 @@
-#Buildere
+# Builder
 FROM rust:1.69-slim-buster AS builder
 ARG BUILDER_DIR=/srv/bitmask
 ARG BUILDER_SRC=/opt/src/bitmask
@@ -12,14 +12,18 @@ COPY . .
 
 RUN cargo install --locked --features server --path . --root ${BUILDER_DIR}
 
-ENV CARBONADO_DIR= "/data/bitmaskd/carbonado/"
+#ARG path
+#ENV  CARBONADO_DIR $path
+#ENV CARBONADO_DIR=/data/bitmaskd/carbonado/
 
 # Runtime
 FROM rust:1.69-slim-buster AS runtime
 
+ENV CARBONADO_DIR=/data/bitmaskd/carbonado/
+
 ARG BUILDER_DIR=/srv/bitmask
 ARG BIN_DIR=/usr/local/bin
-ARG DATA_DIR=/data/bitmaskd/carbonado/
+ARG DATA_DIR=/tmp/bitmaskd/carbonado/
 ARG USER=bitmask
 
 RUN apt-get update -y && apt-get install -y iputils-ping telnet \
@@ -35,7 +39,6 @@ USER ${USER}
 VOLUME ${DATA_DIR}
 EXPOSE 7070
 
-# Set the data directory for data persistence
 WORKDIR ${BIN_DIR}
 
 ENTRYPOINT ["bitmaskd"]


### PR DESCRIPTION
Testing the run command against the Dockerfile with:

docker run -d --restart always -p 7060:7070 -v /Applications/bitmask/bitmask-core/target/release:/app -v /var/lib/docker/volumes/my_data_volume:/_data --name bitmaskd-st160 -t bitmaskd-st160-image:Rc.17 -e “CARBONADO_DIR=/data” 

the volume mounts allow for updating source code, at the same time, writing to the volume data mount