### PR TITLE
Validate nostr keys

### DIFF
--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -40,6 +40,19 @@ fn test_validate_pubkey() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_validate_32bytes_pubkey() -> Result<()> {
+    let result =
+        validate_pubkey("0000066e0359c33a0bed474853a610f744404f265140ecf5171b38483aaea2bb")?;
+
+    assert_eq!(
+        "0000066e0359c33a0bed474853a610f744404f265140ecf5171b38483aaea2bb", result,
+        "32 bytes pubkey"
+    );
+
+    Ok(())
+}
+
 /// Add a new nostr pubkey to a user
 pub async fn new_nostr_pubkey(pubkey: &str, token: &str) -> Result<Response> {
     let pubkey = validate_pubkey(pubkey)?;

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::{constants::LNDHUB_ENDPOINT, util::post_json_auth};
@@ -15,8 +15,35 @@ pub struct Response {
     pub status: String,
 }
 
+fn validate_pubkey(pubkey: &str) -> Result<String> {
+    let pubkey = hex::decode(pubkey)?;
+
+    if pubkey.len() == 32 {
+        Ok(hex::encode(pubkey))
+    } else if pubkey.len() == 33 && (pubkey[0] == 2 || pubkey[0] == 3) {
+        Ok(hex::encode(pubkey.get(1..33).unwrap()))
+    } else {
+        Err(anyhow!("Hex key is of wrong length or format"))
+    }
+}
+
+#[test]
+fn test_validate_pubkey() -> Result<()> {
+    let result =
+        validate_pubkey("03b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9")?;
+
+    assert_eq!(
+        "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", result,
+        "strips leading parity byte on 33 byte x-only pubkey"
+    );
+
+    Ok(())
+}
+
 /// Add a new nostr pubkey to a user
 pub async fn new_nostr_pubkey(pubkey: &str, token: &str) -> Result<Response> {
+    let pubkey = validate_pubkey(pubkey)?;
+
     let endpoint = LNDHUB_ENDPOINT.read().await;
     let pubkey = Nostr {
         pubkey: pubkey.to_string(),
@@ -31,6 +58,8 @@ pub async fn new_nostr_pubkey(pubkey: &str, token: &str) -> Result<Response> {
 
 /// Update the user nostr pubkey
 pub async fn update_nostr_pubkey(pubkey: &str, token: &str) -> Result<Response> {
+    let pubkey = validate_pubkey(pubkey)?;
+
     let endpoint = LNDHUB_ENDPOINT.read().await;
     let pubkey = Nostr {
         pubkey: pubkey.to_string(),


### PR DESCRIPTION
Validate nostr keys and trim them if slightly too long (33 byte x-only pk).

This way the key from `vault.public.nostr_pub` can be provided directly, otherwise, the way we generate it, it's just a little too long. We generate it this way because the extra byte is helpful for Carbonado encryption.