### PR TITLE
fix: blank transition for different contract types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.10.4"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc17#b7e4b4bd1a901f4c805005844b71c834ef53253b"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc17#b6806e7fee07e9c7ee5bc20df6a8fde2678e026c"
 dependencies = [
  "amplify",
  "baid58",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "rgb-wallet"
 version = "0.10.4"
-source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc17#b7e4b4bd1a901f4c805005844b71c834ef53253b"
+source = "git+https://github.com/crisdut/rgb-wallet?branch=release/bmc-v0.6-rc17#b6806e7fee07e9c7ee5bc20df6a8fde2678e026c"
 dependencies = [
  "amplify",
  "baid58",


### PR DESCRIPTION
**Description**

This PR has an interim fix that allows you to create transitions for all contracts linked to the single UTXO, regardless of its implementation (iface).