### PR TITLE
Fix watcher next utxos

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::{
+    collections::{BTreeMap, HashSet},
+    str::FromStr,
+};
 
 use ::psbt::serialize::Serialize;
 use amplify::hex::ToHex;
@@ -1434,7 +1437,7 @@ pub async fn watcher_unspent_utxos(sk: &str, name: &str, iface: &str) -> Result<
     prefetch_resolver_utxo_status(iface_index, &mut wallet, &mut resolver).await;
 
     sync_wallet(iface_index, &mut wallet, &mut resolver);
-    let utxos = next_utxos(iface_index, wallet.clone(), &mut resolver)?
+    let utxos: HashSet<UtxoResponse> = next_utxos(iface_index, wallet.clone(), &mut resolver)?
         .into_iter()
         .map(|x| UtxoResponse {
             outpoint: x.outpoint.to_string(),
@@ -1447,7 +1450,9 @@ pub async fn watcher_unspent_utxos(sk: &str, name: &str, iface: &str) -> Result<
         .insert(RGB_DEFAULT_NAME.to_string(), wallet);
     store_wallets(sk, ASSETS_WALLETS, &rgb_account).await?;
 
-    Ok(NextUtxosResponse { utxos })
+    Ok(NextUtxosResponse {
+        utxos: utxos.into_iter().collect(),
+    })
 }
 
 pub async fn clear_stock(sk: &str) {

--- a/src/rgb/wallet.rs
+++ b/src/rgb/wallet.rs
@@ -165,13 +165,11 @@ pub fn next_utxos(
     let mut utxos: Vec<Utxo> = wallet
         .utxos
         .into_iter()
-        .filter(|utxo| {
-            utxo.derivation.terminal.app == iface_index && utxo.derivation.tweak.is_none()
-        })
+        .filter(|utxo| utxo.derivation.terminal.app == iface_index)
         .collect();
 
     if utxos.is_empty() {
-        return Ok(none!());
+        return Ok(vec![]);
     }
 
     // TODO: This is really necessary?

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -817,7 +817,7 @@ pub struct NextUtxosResponse {
     pub utxos: Vec<UtxoResponse>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct UtxoResponse {
     pub outpoint: String,


### PR DESCRIPTION
**Description**

This PR fix the method **watcher_next_utxo**, avoiding duplication of the same information and listing UTXOs containing anchored contracts (previously, we prohibited this due to the problem of consecutive transfers, but this filter went unnoticed after the correction).a