### PR TITLE
Support CRDT to RgbWallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "automerge"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6738a70b192adaf8f5393fa286a994393cbfc4b2cb780697d2c423f45c260ab"
+dependencies = [
+ "flate2",
+ "fxhash",
+ "hex",
+ "itertools",
+ "leb128",
+ "serde",
+ "sha2 0.10.7",
+ "smol_str",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "autosurgeon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e5a84cd8615e4baa36c9f14b14f9b310a524e92c16329e3f6684525f466502"
+dependencies = [
+ "automerge",
+ "autosurgeon-derive",
+ "similar",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "autosurgeon-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91bccbe0b61b69be46a0c461c1b287d8a8465a8c83cf770d2a34dd3dc70d8c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smol_str",
+ "syn 2.0.26",
+ "thiserror",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +640,8 @@ dependencies = [
  "amplify",
  "anyhow",
  "argon2",
+ "automerge",
+ "autosurgeon",
  "axum",
  "axum-macros",
  "base64-compat",
@@ -620,7 +668,7 @@ dependencies = [
  "getrandom",
  "gloo-console",
  "gloo-net",
- "gloo-utils",
+ "gloo-utils 0.2.0",
  "hex",
  "indexmap 1.9.3",
  "inflate",
@@ -1410,6 +1458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "garde"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,7 +1531,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
 dependencies = [
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1490,7 +1547,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "http",
  "js-sys",
  "pin-project",
@@ -1519,6 +1576,19 @@ name = "gloo-utils"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
 dependencies = [
  "js-sys",
  "serde",
@@ -1901,6 +1971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1999,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -3166,6 +3251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
 name = "single_use_seals"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3290,15 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -3640,7 +3740,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -3774,6 +3886,16 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ tokio = { version = "1.28.2", features = ["macros", "sync"] }
 zeroize = "1.6.0"
 blake3 = "1.4.1"
 base85 = "2.0.0"
+automerge = "0.5.1"
+autosurgeon = "0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.0", features = [
@@ -95,7 +97,7 @@ bdk = { version = "0.28.0", features = [
 ], default-features = false }
 gloo-console = "0.2.3"
 gloo-net = { version = "0.3.1", features = ["http"] }
-gloo-utils = "0.1.7"
+gloo-utils = "0.2.0"
 js-sys = "0.3.63"
 serde-wasm-bindgen = "0.5.0"
 wasm-bindgen = { version = "0.2.86", features = ["serde-serialize"] }

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -3,10 +3,9 @@
 #![cfg(not(target_arch = "wasm32"))]
 use std::{env, fs::OpenOptions, io::ErrorKind, net::SocketAddr, str::FromStr};
 
-use amplify::hex::ToHex;
 use anyhow::Result;
 use axum::{
-    body::{Bytes, Full},
+    body::Bytes,
     extract::Path,
     headers::{authorization::Bearer, Authorization, CacheControl},
     http::StatusCode,
@@ -16,8 +15,8 @@ use axum::{
 };
 use bitcoin_30::secp256k1::{ecdh::SharedSecret, PublicKey, SecretKey};
 use bitmask_core::{
-    bitcoin::{decrypt_wallet, get_wallet_data, save_mnemonic, sign_psbt_file},
-    carbonado::{handle_file, retrieve, retrieve_metadata},
+    bitcoin::{save_mnemonic, sign_psbt_file},
+    carbonado::handle_file,
     constants::{get_marketplace_seed, get_network, get_udas_utxo, switch_network},
     rgb::{
         accept_transfer, clear_watcher as rgb_clear_watcher, create_invoice, create_psbt,
@@ -29,16 +28,12 @@ use bitmask_core::{
     },
     structs::{
         AcceptRequest, FileMetadata, FullRgbTransferRequest, ImportRequest, InvoiceRequest,
-        IssueAssetRequest, IssueRequest, MediaInfo, PsbtFeeRequest, PsbtRequest, ReIssueRequest,
-        RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbTransferRequest, SecretString,
-        SelfFullRgbTransferRequest, SelfInvoiceRequest, SelfIssueRequest, SignPsbtRequest,
-        WatcherRequest,
+        IssueRequest, PsbtFeeRequest, PsbtRequest, ReIssueRequest, RgbRemoveTransferRequest,
+        RgbSaveTransferRequest, RgbTransferRequest, SecretString, SelfFullRgbTransferRequest,
+        SelfInvoiceRequest, SelfIssueRequest, SignPsbtRequest, WatcherRequest,
     },
 };
-use carbonado::file;
 use log::{debug, error, info};
-use rgbstd::interface::Iface;
-use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tower_http::cors::CorsLayer;
 
@@ -636,10 +631,10 @@ async fn main() -> Result<()> {
         .route("/transfers/", delete(remove_transfer))
         .route("/key/:pk", get(key))
         .route("/carbonado/status", get(status))
+        .route("/carbonado/:pk/:name", get(co_retrieve))
         .route("/carbonado/:pk/:name", post(co_store))
         .route("/carbonado/:pk/:name/force", post(co_force_store))
-        .route("/carbonado/:pk/:name/metadata", get(co_metadata))
-        .route("/carbonado/:pk/:name", get(co_retrieve));
+        .route("/carbonado/:pk/:name/metadata", get(co_metadata));
 
     let network = get_network().await;
     switch_network(&network).await?;

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -1,9 +1,12 @@
 use amplify::confinement::{Confined, U32};
 use anyhow::Result;
+use autosurgeon::{hydrate, reconcile};
 use postcard::{from_bytes, to_allocvec};
 use rgbstd::{persistence::Stock, stl::LIB_ID_RGB};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
+use crate::rgb::crdt::LocalRgbAccount;
+use crate::rgb::crdt::RawRgbAccount;
 use crate::rgb::structs::RgbTransfers;
 use crate::{
     carbonado::{retrieve, store},
@@ -13,14 +16,32 @@ use crate::{
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
 #[display(doc_comments)]
 pub enum StorageError {
+    /// File '{0}' retrieve causes error. {1}
+    FileRetrieve(String, String),
+    /// File '{0}' write causes error. {1}
+    WriteRetrieve(String, String),
+    /// Changes '{0}' retrieve causes error. {1}
+    ChangesRetrieve(String, String),
+    /// Changes '{0}' write causes error. {1}
+    ChangesWrite(String, String),
+    /// Fork '{0}' write causes error. {1}
+    ForkWrite(String, String),
+    /// Merge '{0}' write causes error. {1}
+    MergeWrite(String, String),
     /// Retrieve '{0}' strict-encoding causes error. {1}
-    StrictRetrive(String, String),
+    StrictRetrieve(String, String),
     /// Write '{0}' strict-encoding causes error. {1}
     StrictWrite(String, String),
+    /// Retrieve '{0}' serialize causes error. {1}
+    SerializeRetrieve(String, String),
+    /// Write '{0}' serialize causes error. {1}
+    SerializeWrite(String, String),
     /// Retrieve '{0}' carbonado causes error. {1}
-    CarbonadoRetrive(String, String),
+    CarbonadoRetrieve(String, String),
     /// Write '{0}' carbonado causes error. {1}
     CarbonadoWrite(String, String),
+    /// Reconcile '{0}' causes error. {1}
+    Reconcile(String, String),
 }
 
 pub async fn store_stock(sk: &str, name: &str, stock: &Stock) -> Result<(), StorageError> {
@@ -41,47 +62,6 @@ pub async fn store_stock(sk: &str, name: &str, stock: &Stock) -> Result<(), Stor
     )
     .await
     .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))
-}
-
-pub async fn force_store_stock(sk: &str, name: &str, stock: &Stock) -> Result<(), StorageError> {
-    let data = stock
-        .to_strict_serialized::<U32>()
-        .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
-
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
-        .to_hex()
-        .to_lowercase();
-
-    store(
-        sk,
-        &hashed_name,
-        &data,
-        true,
-        Some(RGB_STRICT_TYPE_VERSION.to_vec()),
-    )
-    .await
-    .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))
-}
-
-pub async fn retrieve_stock(sk: &str, name: &str) -> Result<Stock, StorageError> {
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
-        .to_hex()
-        .to_lowercase();
-
-    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
-        .await
-        .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
-
-    if data.is_empty() {
-        Ok(Stock::default())
-    } else {
-        let confined = Confined::try_from_iter(data)
-            .map_err(|op| StorageError::StrictRetrive(name.to_string(), op.to_string()))?;
-        let stock = Stock::from_strict_serialized::<U32>(confined)
-            .map_err(|op| StorageError::StrictRetrive(name.to_string(), op.to_string()))?;
-
-        Ok(stock)
-    }
 }
 
 pub async fn store_wallets(
@@ -107,47 +87,6 @@ pub async fn store_wallets(
     .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))
 }
 
-pub async fn force_store_wallets(
-    sk: &str,
-    name: &str,
-    rgb_wallets: &RgbAccount,
-) -> Result<(), StorageError> {
-    let data = to_allocvec(rgb_wallets)
-        .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
-
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
-        .to_hex()
-        .to_lowercase();
-
-    store(
-        sk,
-        &format!("{hashed_name}.c15"),
-        &data,
-        true,
-        Some(RGB_STRICT_TYPE_VERSION.to_vec()),
-    )
-    .await
-    .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))
-}
-
-pub async fn retrieve_wallets(sk: &str, name: &str) -> Result<RgbAccount, StorageError> {
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
-        .to_hex()
-        .to_lowercase();
-
-    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
-        .await
-        .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
-
-    if data.is_empty() {
-        Ok(RgbAccount::default())
-    } else {
-        let rgb_wallets = from_bytes(&data)
-            .map_err(|op| StorageError::StrictRetrive(name.to_string(), op.to_string()))?;
-        Ok(rgb_wallets)
-    }
-}
-
 pub async fn store_transfers(
     sk: &str,
     name: &str,
@@ -171,6 +110,45 @@ pub async fn store_transfers(
     .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))
 }
 
+pub async fn retrieve_stock(sk: &str, name: &str) -> Result<Stock, StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
+    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
+
+    if data.is_empty() {
+        Ok(Stock::default())
+    } else {
+        let confined = Confined::try_from_iter(data)
+            .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+        let stock = Stock::from_strict_serialized::<U32>(confined)
+            .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+
+        Ok(stock)
+    }
+}
+
+pub async fn retrieve_wallets(sk: &str, name: &str) -> Result<RgbAccount, StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
+    let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
+
+    if data.is_empty() {
+        Ok(RgbAccount::default())
+    } else {
+        let rgb_wallets = from_bytes(&data)
+            .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+        Ok(rgb_wallets)
+    }
+}
+
 pub async fn retrieve_transfers(sk: &str, name: &str) -> Result<RgbTransfers, StorageError> {
     let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
         .to_hex()
@@ -178,13 +156,116 @@ pub async fn retrieve_transfers(sk: &str, name: &str) -> Result<RgbTransfers, St
 
     let (data, _) = retrieve(sk, &format!("{hashed_name}.c15"), vec![])
         .await
-        .map_err(|op| StorageError::CarbonadoRetrive(name.to_string(), op.to_string()))?;
+        .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
 
     if data.is_empty() {
         Ok(RgbTransfers::default())
     } else {
         let rgb_wallets = from_bytes(&data)
-            .map_err(|op| StorageError::StrictRetrive(name.to_string(), op.to_string()))?;
+            .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
         Ok(rgb_wallets)
+    }
+}
+
+pub async fn store_fork_wallets(sk: &str, name: &str, changes: &[u8]) -> Result<(), StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
+    let main_name = &format!("{hashed_name}.c15");
+    let original_name = &format!("{hashed_name}-diff.c15");
+
+    // let mut original_version = automerge::AutoCommit::new();
+    // let (main_bytes, _) = retrieve(sk, &main_name, vec![])
+    //     .await
+    //     .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
+
+    // let original: RgbAccount = from_bytes(&main_bytes)
+    //     .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+
+    // let raw_data = RawRgbAccount::from(original);
+    // reconcile(&mut original_version, raw_data)
+    //     .map_err(|op| StorageError::Reconcile(name.to_string(), op.to_string()))?;
+
+    let (original_bytes, _) = retrieve(sk, original_name, vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
+
+    let mut original_version = automerge::AutoCommit::load(&original_bytes)
+        .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+
+    let mut fork_version = automerge::AutoCommit::load(changes)
+        .map_err(|op| StorageError::ChangesRetrieve(name.to_string(), op.to_string()))?;
+
+    original_version
+        .merge(&mut fork_version)
+        .map_err(|op| StorageError::MergeWrite(name.to_string(), op.to_string()))?;
+
+    let raw_merged: RawRgbAccount = hydrate(&original_version).unwrap();
+    let merged: RgbAccount = RgbAccount::from(raw_merged.clone());
+
+    let mut latest_version = automerge::AutoCommit::new();
+    reconcile(&mut latest_version, raw_merged)
+        .map_err(|op| StorageError::WriteRetrieve(name.to_string(), op.to_string()))?;
+
+    let data = to_allocvec(&merged)
+        .map_err(|op| StorageError::StrictWrite(name.to_string(), op.to_string()))?;
+
+    store(
+        sk,
+        main_name,
+        &data,
+        true,
+        Some(RGB_STRICT_TYPE_VERSION.to_vec()),
+    )
+    .await
+    .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))?;
+
+    Ok(())
+}
+
+pub async fn retrieve_fork_wallets(sk: &str, name: &str) -> Result<LocalRgbAccount, StorageError> {
+    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+        .to_hex()
+        .to_lowercase();
+
+    let main_name = &format!("{hashed_name}.c15");
+    let original_name = &format!("{hashed_name}-diff.c15");
+
+    let (data, _) = retrieve(sk, main_name, vec![])
+        .await
+        .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
+
+    if data.is_empty() {
+        Ok(LocalRgbAccount {
+            doc: automerge::AutoCommit::new().save(),
+            rgb_account: RgbAccount::default(),
+        })
+    } else {
+        let mut original_version = automerge::AutoCommit::new();
+        let rgb_account: RgbAccount = from_bytes(&data)
+            .map_err(|op| StorageError::StrictRetrieve(name.to_string(), op.to_string()))?;
+
+        let raw_rgb_account = RawRgbAccount::from(rgb_account.clone());
+        reconcile(&mut original_version, raw_rgb_account.clone())
+            .map_err(|op| StorageError::Reconcile(name.to_string(), op.to_string()))?;
+
+        let mut fork_version = original_version.fork();
+        let original_version = fork_version.save();
+
+        store(
+            sk,
+            original_name,
+            &original_version,
+            true,
+            Some(RGB_STRICT_TYPE_VERSION.to_vec()),
+        )
+        .await
+        .map_err(|op| StorageError::CarbonadoWrite(name.to_string(), op.to_string()))?;
+
+        Ok(LocalRgbAccount {
+            doc: fork_version.save(),
+            rgb_account,
+        })
     }
 }

--- a/src/rgb/crdt.rs
+++ b/src/rgb/crdt.rs
@@ -1,0 +1,286 @@
+use amplify::hex::ToHex;
+use autosurgeon::{Hydrate, Reconcile};
+use bitcoin::OutPoint;
+use bitcoin_30::bip32::ExtendedPubKey;
+use bp::{dbc::tapret::TapretCommitment, Outpoint};
+use rgb::{DeriveInfo, RgbDescr, RgbWallet, Tapret, TerminalPath, Utxo};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
+
+use crate::rgb::structs::RgbAccount;
+
+#[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
+#[display(doc_comments)]
+pub enum RgbMergeError {
+    /// Invalid Tapret Wallet Format
+    NoTapret,
+}
+
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone, Reconcile, Hydrate, Default, Display)]
+#[display(doc_comments)]
+pub struct RawRgbAccount {
+    pub wallets: HashMap<String, RawRgbWallet>,
+}
+
+impl From<RgbAccount> for RawRgbAccount {
+    fn from(wallet: RgbAccount) -> Self {
+        Self {
+            wallets: wallet
+                .wallets
+                .into_iter()
+                .map(|(name, wallet)| (name, RawRgbWallet::from(wallet)))
+                .collect(),
+        }
+    }
+}
+
+impl From<RawRgbAccount> for RgbAccount {
+    fn from(raw_account: RawRgbAccount) -> Self {
+        Self {
+            wallets: raw_account
+                .wallets
+                .into_iter()
+                .map(|(name, wallet)| (name, RgbWallet::from(wallet)))
+                .collect(),
+        }
+    }
+}
+
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone, Reconcile, Hydrate, Default, Display)]
+#[display(doc_comments)]
+pub struct RawRgbWallet {
+    pub xpub: String,
+    pub taprets: BTreeMap<String, Vec<String>>,
+    pub utxos: Vec<RawUtxo>,
+}
+
+impl From<RgbWallet> for RawRgbWallet {
+    fn from(wallet: RgbWallet) -> Self {
+        let RgbDescr::Tapret(tapret) = wallet.descr;
+
+        let mut raw_uxtos = vec![];
+        let mut raw_taprets = BTreeMap::new();
+        for (terminal_path, taprets) in tapret.taprets {
+            let TerminalPath { app, index } = terminal_path;
+            raw_taprets.insert(
+                format!("{app}:{index}"),
+                taprets.into_iter().map(|tap| tap.to_string()).collect(),
+            );
+        }
+
+        for utxo in wallet.utxos {
+            raw_uxtos.push(RawUtxo::from(utxo));
+        }
+
+        Self {
+            xpub: tapret.xpub.to_string(),
+            taprets: raw_taprets,
+            utxos: raw_uxtos,
+        }
+    }
+}
+
+impl From<RawRgbWallet> for RgbWallet {
+    fn from(raw_wallet: RawRgbWallet) -> Self {
+        let xpub = ExtendedPubKey::from_str(&raw_wallet.xpub).expect("invalid xpub");
+        let mut tapret = Tapret {
+            xpub,
+            taprets: BTreeMap::new(),
+        };
+
+        for (raw_terminal, raw_tweaks) in raw_wallet.taprets {
+            let mut split = raw_terminal.split(':');
+            let app = split.next().unwrap();
+            let index = split.next().unwrap();
+
+            let terminal = TerminalPath {
+                app: app.parse().expect("invalid terminal path app"),
+                index: index.parse().expect("invalid terminal path index"),
+            };
+
+            let taprets = raw_tweaks
+                .into_iter()
+                .map(|tap| TapretCommitment::from_str(&tap).expect("invalid taptweak format"))
+                .collect();
+
+            tapret.taprets.insert(terminal, taprets);
+        }
+        Self {
+            descr: RgbDescr::Tapret(tapret),
+            utxos: raw_wallet.utxos.into_iter().map(Utxo::from).collect(),
+        }
+    }
+}
+
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone, Reconcile, Hydrate, Default, Display)]
+#[display(doc_comments)]
+pub struct RawUtxo {
+    pub outpoint: String,
+    pub block: u32,
+    pub amount: u64,
+    // DeriveInfo,
+    pub terminal: String,
+    pub tweak: Option<String>,
+}
+
+impl From<RawUtxo> for Utxo {
+    fn from(raw_utxo: RawUtxo) -> Self {
+        let mut split = raw_utxo.terminal.split(':');
+        let app = split.next().unwrap();
+        let index = split.next().unwrap();
+
+        let terminal = TerminalPath {
+            app: app.parse().expect("invalid terminal path app"),
+            index: index.parse().expect("invalid terminal path index"),
+        };
+
+        let mut tweak = none!();
+        if let Some(taptweak) = raw_utxo.tweak {
+            tweak = Some(TapretCommitment::from_str(&taptweak).expect("invalid taptweak format"));
+        }
+
+        let derive_info = DeriveInfo { terminal, tweak };
+
+        let outpoint = OutPoint::from_str(&raw_utxo.outpoint).expect("invalid outpoint parse");
+        let txid = bp::Txid::from_str(&outpoint.txid.to_hex()).expect("invalid txid");
+
+        Self {
+            outpoint: Outpoint::new(txid, outpoint.vout),
+            status: rgb::MiningStatus::Mempool,
+            amount: raw_utxo.amount,
+            derivation: derive_info,
+        }
+    }
+}
+
+impl From<Utxo> for RawUtxo {
+    fn from(utxo: Utxo) -> Self {
+        let Utxo {
+            outpoint,
+            status,
+            amount,
+            derivation:
+                DeriveInfo {
+                    terminal: TerminalPath { app, index },
+                    tweak,
+                },
+        } = utxo;
+
+        let mut tap_tweak = none!();
+        if let Some(tap) = tweak {
+            tap_tweak = Some(tap.to_string())
+        }
+
+        let block = match status {
+            rgb::MiningStatus::Mempool => 0,
+            rgb::MiningStatus::Blockchain(block) => block,
+        };
+
+        Self {
+            outpoint: outpoint.to_string(),
+            block,
+            amount,
+            terminal: format!("{app}:{index}"),
+            tweak: tap_tweak,
+        }
+    }
+}
+
+pub trait RgbMerge<T> {
+    fn update(self, rgb_data: &mut T);
+}
+
+impl RgbMerge<RawRgbAccount> for RgbAccount {
+    fn update(self, rgb_data: &mut RawRgbAccount) {
+        for (name, wallet) in self.wallets {
+            if let Some(raw_wallet) = rgb_data.wallets.get(&name) {
+                let mut raw_wallet = raw_wallet.clone();
+                wallet.update(&mut raw_wallet);
+                rgb_data.wallets.insert(name, raw_wallet);
+            } else {
+                rgb_data.wallets.insert(name, RawRgbWallet::from(wallet));
+            }
+        }
+    }
+}
+
+impl RgbMerge<RawRgbWallet> for RgbWallet {
+    fn update(self, rgb_data: &mut RawRgbWallet) {
+        let RgbDescr::Tapret(tapret) = self.descr;
+
+        for (terminal_path, taprets) in tapret.taprets {
+            let TerminalPath { app, index } = terminal_path;
+            let terminal = format!("{app}:{index}");
+
+            let mut current_taprets = match rgb_data.taprets.get(&terminal) {
+                Some(taprets) => taprets.clone(),
+                None => vec![],
+            };
+
+            let new_taprets: Vec<String> = taprets.into_iter().map(|tap| tap.to_string()).collect();
+
+            for new_tapret in new_taprets {
+                if !current_taprets.contains(&new_tapret) {
+                    current_taprets.push(new_tapret);
+                }
+            }
+
+            rgb_data.taprets.insert(terminal, current_taprets);
+        }
+
+        for utxo in self.utxos {
+            let new_utxo = RawUtxo::from(utxo);
+            if !rgb_data.utxos.contains(&new_utxo) {
+                rgb_data.utxos.push(new_utxo);
+            }
+        }
+    }
+}
+
+impl RgbMerge<RawUtxo> for Utxo {
+    fn update(self, rgb_data: &mut RawUtxo) {
+        let Utxo {
+            status,
+            amount,
+            derivation: DeriveInfo { tweak, .. },
+            ..
+        } = self;
+
+        if rgb_data.amount != amount {
+            rgb_data.amount = amount;
+        }
+
+        if rgb_data.block == 0 {
+            rgb_data.block = match status {
+                rgb::MiningStatus::Mempool => 0,
+                rgb::MiningStatus::Blockchain(block) => block,
+            };
+        }
+
+        let new_tap = if let Some(new_tap) = tweak {
+            Some(new_tap.to_string())
+        } else {
+            none!()
+        };
+
+        if rgb_data.tweak.is_none() {
+            rgb_data.tweak = new_tap;
+        };
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Display)]
+#[display(doc_comments)]
+pub struct LocalRgbAccount {
+    pub doc: Vec<u8>,
+    pub rgb_account: RgbAccount,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LocalCopyData {
+    pub doc: Vec<u8>,
+    pub data: Vec<u8>,
+}

--- a/src/rgb/fs.rs
+++ b/src/rgb/fs.rs
@@ -1,47 +1,65 @@
 use rgbstd::persistence::Stock;
 
 use crate::constants::storage_keys::{ASSETS_STOCK, ASSETS_TRANSFERS, ASSETS_WALLETS};
-
-use super::{
+use crate::rgb::{
     carbonado::{
-        retrieve_stock as retrieve_rgb_stock, retrieve_transfers as retrieve_rgb_transfers,
-        retrieve_wallets, store_stock as store_rgb_stock, store_transfers as store_rgb_transfer,
-        store_wallets as store_rgb_account,
+        retrieve_fork_wallets, retrieve_stock as retrieve_rgb_stock,
+        retrieve_transfers as retrieve_rgb_transfers, retrieve_wallets, store_fork_wallets,
+        store_stock as store_rgb_stock, store_transfers as store_rgb_transfer, store_wallets,
     },
+    crdt::LocalRgbAccount,
     structs::{RgbAccount, RgbTransfers},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
 #[display(doc_comments)]
 pub enum RgbPersistenceError {
-    RetrieveStock,
-    RetrieveRgbAccount,
-    RetrieveRgbTransfers,
-    WriteStock,
-    WriteRgbAccount,
-    WriteRgbTransfers,
+    // Retrieve Stock Error. {0}
+    RetrieveStock(String),
+    // Retrieve RgbAccount Error. {0}
+    RetrieveRgbAccount(String),
+    // Retrieve RgbAccount (Fork) Error. {0}
+    RetrieveRgbAccountFork(String),
+    // Retrieve Transfers Error. {0}
+    RetrieveRgbTransfers(String),
+    // Store Stock Error. {0}
+    WriteStock(String),
+    // Store RgbAccount Error. {0}
+    WriteRgbAccount(String),
+    // Store RgbAccount (Fork) Error. {0}
+    WriteRgbAccountFork(String),
+    // Store Transfers Error. {0}
+    WriteRgbTransfers(String),
 }
 
 pub async fn retrieve_stock(sk: &str) -> Result<Stock, RgbPersistenceError> {
     let stock = retrieve_rgb_stock(sk, ASSETS_STOCK)
         .await
-        .map_err(|_| RgbPersistenceError::RetrieveStock)?;
+        .map_err(|op| RgbPersistenceError::RetrieveStock(op.to_string()))?;
 
     Ok(stock)
-}
-
-pub async fn retrieve_account(sk: &str) -> Result<RgbAccount, RgbPersistenceError> {
-    let rgb_account = retrieve_wallets(sk, ASSETS_WALLETS)
-        .await
-        .map_err(|_| RgbPersistenceError::RetrieveRgbAccount)?;
-
-    Ok(rgb_account)
 }
 
 pub async fn retrieve_transfers(sk: &str) -> Result<RgbTransfers, RgbPersistenceError> {
     let rgb_account = retrieve_rgb_transfers(sk, ASSETS_TRANSFERS)
         .await
-        .map_err(|_| RgbPersistenceError::RetrieveRgbTransfers)?;
+        .map_err(|op| RgbPersistenceError::RetrieveRgbTransfers(op.to_string()))?;
+
+    Ok(rgb_account)
+}
+
+pub async fn retrieve_account(sk: &str) -> Result<RgbAccount, RgbPersistenceError> {
+    let rgb_account = retrieve_wallets(sk, ASSETS_WALLETS)
+        .await
+        .map_err(|op| RgbPersistenceError::RetrieveRgbAccount(op.to_string()))?;
+
+    Ok(rgb_account)
+}
+
+pub async fn retrieve_local_account(sk: &str) -> Result<LocalRgbAccount, RgbPersistenceError> {
+    let rgb_account = retrieve_fork_wallets(sk, ASSETS_WALLETS)
+        .await
+        .map_err(|op| RgbPersistenceError::RetrieveRgbAccountFork(op.to_string()))?;
 
     Ok(rgb_account)
 }
@@ -69,19 +87,25 @@ pub async fn retrieve_stock_account_transfers(
 pub async fn store_stock(sk: &str, stock: Stock) -> Result<(), RgbPersistenceError> {
     store_rgb_stock(sk, ASSETS_STOCK, &stock)
         .await
-        .map_err(|_| RgbPersistenceError::WriteStock)
-}
-
-pub async fn store_account(sk: &str, account: RgbAccount) -> Result<(), RgbPersistenceError> {
-    store_rgb_account(sk, ASSETS_WALLETS, &account)
-        .await
-        .map_err(|_| RgbPersistenceError::WriteRgbAccount)
+        .map_err(|op| RgbPersistenceError::WriteStock(op.to_string()))
 }
 
 pub async fn store_transfers(sk: &str, transfers: RgbTransfers) -> Result<(), RgbPersistenceError> {
     store_rgb_transfer(sk, ASSETS_TRANSFERS, &transfers)
         .await
-        .map_err(|_| RgbPersistenceError::WriteRgbTransfers)
+        .map_err(|op| RgbPersistenceError::WriteRgbTransfers(op.to_string()))
+}
+
+pub async fn store_account(sk: &str, account: RgbAccount) -> Result<(), RgbPersistenceError> {
+    store_wallets(sk, ASSETS_WALLETS, &account)
+        .await
+        .map_err(|op| RgbPersistenceError::WriteRgbAccount(op.to_string()))
+}
+
+pub async fn store_local_account(sk: &str, changes: Vec<u8>) -> Result<(), RgbPersistenceError> {
+    store_fork_wallets(sk, ASSETS_WALLETS, &changes)
+        .await
+        .map_err(|op| RgbPersistenceError::WriteRgbAccountFork(op.to_string()))
 }
 
 pub async fn store_stock_account(

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -156,7 +156,7 @@ pub async fn prebuild_transfer_asset(
     }
 
     let asset_unspent_utxos = &mut next_utxos(contract_index, rgb_wallet.clone(), resolver)
-        .map_err(|_| TransferError::IO(RgbPersistenceError::RetrieveRgbAccount))?;
+        .map_err(|_| TransferError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string())))?;
 
     let mut asset_total = 0;
     let mut asset_inputs = vec![];
@@ -249,7 +249,9 @@ pub async fn prebuild_transfer_asset(
             prefetch_resolver_user_utxo_status(bitcoin_index, rgb_wallet, resolver, false).await;
 
             let mut unspent_utxos = next_utxos(bitcoin_index, rgb_wallet.clone(), resolver)
-                .map_err(|_| TransferError::IO(RgbPersistenceError::RetrieveRgbAccount))?;
+                .map_err(|_| {
+                    TransferError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string()))
+                })?;
 
             all_unspents.append(&mut unspent_utxos);
         }

--- a/src/rgb/prefetch.rs
+++ b/src/rgb/prefetch.rs
@@ -300,6 +300,7 @@ pub async fn prefetch_resolver_utxos(
     explorer: &mut ExplorerResolver,
     limit: Option<u32>,
 ) {
+    // use crate::debug;
     use std::collections::HashSet;
     let esplora_client: EsploraBlockchain =
         EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
@@ -382,12 +383,16 @@ pub async fn prefetch_resolver_utxos(
             .find(|u| u.outpoint == new_utxo.outpoint)
         {
             if current_utxo.status == MiningStatus::Mempool {
-                wallet.utxos.remove(&current_utxo);
+                wallet.utxos.remove(&current_utxo.clone());
+                explorer.utxos.insert(current_utxo.clone());
+
                 new_utxo.derivation = current_utxo.derivation;
-                wallet.utxos.insert(new_utxo);
+                wallet.utxos.insert(new_utxo.clone());
+                explorer.utxos.insert(new_utxo);
             }
         } else {
-            wallet.utxos.insert(new_utxo);
+            wallet.utxos.insert(new_utxo.clone());
+            explorer.utxos.insert(new_utxo);
         }
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -882,8 +882,9 @@ pub struct NextUtxosResponse {
     pub utxos: Vec<UtxoResponse>,
 }
 
-#[derive(Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Clone, Default, Display)]
 #[serde(rename_all = "camelCase")]
+#[display("{outpoint}:{amount}")]
 pub struct UtxoResponse {
     pub outpoint: String,
     pub amount: u64,

--- a/src/web.rs
+++ b/src/web.rs
@@ -95,6 +95,16 @@ pub mod constants {
             Ok(JsValue::UNDEFINED)
         })
     }
+
+    #[wasm_bindgen]
+    pub fn sleep(ms: i32) -> js_sys::Promise {
+        js_sys::Promise::new(&mut |resolve, _| {
+            web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+                .unwrap();
+        })
+    }
 }
 
 pub mod bitcoin {
@@ -107,6 +117,20 @@ pub mod bitcoin {
         crate::bitcoin::hash_password(&SecretString(password))
             .0
             .to_owned()
+    }
+
+    #[wasm_bindgen]
+    pub fn new_mnemonic(password: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::bitcoin::new_mnemonic(&SecretString(password)).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
     }
 
     #[wasm_bindgen]

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -14,6 +14,7 @@ mod rgb {
         // mod collectibles;
         mod accept;
         mod collectibles;
+        mod crdt;
         mod drain;
         mod dustless;
         mod fungibles;

--- a/tests/rgb/integration/crdt.rs
+++ b/tests/rgb/integration/crdt.rs
@@ -1,0 +1,77 @@
+#![cfg(not(target_arch = "wasm32"))]
+use crate::rgb::integration::utils::get_raw_wallet;
+use amplify::confinement::Collection;
+use automerge::AutoCommit;
+use autosurgeon::{hydrate, reconcile};
+use bitmask_core::rgb::crdt::{RawRgbWallet, RawUtxo};
+use rgb::{RgbWallet, Utxo};
+
+#[tokio::test]
+async fn allow_fork_with_previous_version() -> anyhow::Result<()> {
+    let current_raw_wallet = get_raw_wallet();
+    let new_raw_utxo = RawUtxo {
+        outpoint: "9a5d21d4cc15ffa14c6f416396235c082cddb5e227abd863974445709f8e9af0:0".to_string(),
+        block: 0,
+        amount: 10000000,
+        terminal: "20:1".to_string(),
+        tweak: Some("tapret02p3PfJiAs6WexAGDDKLyfRqfFaoPG5VFoc6gnqw3q9zQt1shWmF".to_string()),
+    };
+
+    let new_utxo = Utxo::from(new_raw_utxo);
+    let mut rgb_wallet = RgbWallet::from(current_raw_wallet.clone());
+
+    let mut original = AutoCommit::new();
+    reconcile(&mut original, current_raw_wallet)?;
+
+    let mut fork = original.fork();
+
+    rgb_wallet.utxos.push(new_utxo.clone());
+    let latest = RawRgbWallet::from(rgb_wallet);
+    reconcile(&mut fork, latest)?;
+
+    original.merge(&mut fork)?;
+
+    let merged: RawRgbWallet = hydrate(&original).unwrap();
+    let merged = RgbWallet::from(merged);
+
+    assert!(merged.utxo(new_utxo.outpoint).is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn allow_fork_without_previous_version() -> anyhow::Result<()> {
+    let current_raw_wallet = get_raw_wallet();
+    let new_raw_utxo = RawUtxo {
+        outpoint: "9a5d21d4cc15ffa14c6f416396235c082cddb5e227abd863974445709f8e9af0:0".to_string(),
+        block: 0,
+        amount: 10000000,
+        terminal: "20:1".to_string(),
+        tweak: Some("tapret02p3PfJiAs6WexAGDDKLyfRqfFaoPG5VFoc6gnqw3q9zQt1shWmF".to_string()),
+    };
+
+    let new_utxo = Utxo::from(new_raw_utxo);
+    let mut rgb_wallet = RgbWallet::from(current_raw_wallet.clone());
+
+    // Create Original
+    let mut original = AutoCommit::new();
+    reconcile(&mut original, current_raw_wallet.clone())?;
+
+    // Rebase Fork
+    let mut fork = original.fork();
+
+    rgb_wallet.utxos.push(new_utxo.clone());
+    let latest = RawRgbWallet::from(rgb_wallet);
+    reconcile(&mut fork, latest)?;
+
+    // Rebase Original
+    let mut original = AutoCommit::new();
+    original.merge(&mut fork)?;
+
+    let merged: RawRgbWallet = hydrate(&original).unwrap();
+    let merged = RgbWallet::from(merged);
+
+    assert!(merged.utxo(new_utxo.outpoint).is_some());
+
+    Ok(())
+}

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -2,10 +2,12 @@
 #![cfg(not(target_arch = "wasm32"))]
 use std::{collections::HashMap, env, process::Stdio};
 
+use amplify::bmap;
 use bdk::wallet::AddressIndex;
 use bitmask_core::{
     bitcoin::{get_wallet, get_wallet_data, save_mnemonic, sync_wallet},
     rgb::{
+        crdt::{RawRgbWallet, RawUtxo},
         create_invoice, create_psbt, create_watcher, import, issue_contract, transfer_asset,
         watcher_details, watcher_next_address, watcher_next_utxo, watcher_unspent_utxos,
     },
@@ -613,4 +615,50 @@ pub fn _get_collectible_data() -> IssueMetaRequest {
             ..Default::default()
         },
     ]))
+}
+
+pub fn get_raw_wallet() -> RawRgbWallet {
+    RawRgbWallet {
+        xpub: "tpubDCBwP45jcvCdTBZSxn8TcCyQGx5YgietksRRptV9YJ1xnom6edMwb2JcBnNU15t6TmotHETmgnvHQ2Nki7N7CsgFhka6D91UgMaEYpTRuSh".to_string(),
+        taprets: bmap!{
+            "20:1".to_string() => vec![
+                "tapret054mNJMWTUsdX429C87Zi2AFr25cNGo6pxWeoEEsPExx8YNdxnCk".to_string(),
+                "tapret02Mq47rPbJsankXcDd3PDQaBhL1iDnELdqV6xz5eUiZVJYhLeVwu".to_string(),
+            ],
+        },
+        utxos: vec![
+            RawUtxo {
+                outpoint: "38de2eb14e917a066cda3283a9409ca4742427b00b070bda055cb82334d2d309:1".to_string(),
+                block: 904,
+                amount: 1000,
+                terminal: "20:0".to_string(),
+                tweak: None,
+            },
+            RawUtxo {
+                outpoint: "866c629038b8cca56908f5989a4a2dde7942b41f3093212980c1ce388207ddf0:0".to_string(),
+                block: 901,
+                amount: 1000,
+                terminal: "20:0".to_string(),
+                tweak: None,
+            },
+            RawUtxo {
+                outpoint: "1ded068d67c5c16d8ed0c551502c855a5242f22eda06e1e129b396afb3ace9f3:0".to_string(),
+                block: 0,
+                amount: 10000000,
+                terminal: "20:1".to_string(),
+                tweak: Some(
+                    "tapret054mNJMWTUsdX429C87Zi2AFr25cNGo6pxWeoEEsPExx8YNdxnCk".to_string(),
+                ),
+            },
+            RawUtxo {
+                outpoint: "adddea20b187cce1f03c45f7f8023f88541cfdd24725bcf9bbfd9472ea512548:0".to_string(),
+                block: 0,
+                amount: 10000000,
+                terminal: "20:1".to_string(),
+                tweak: Some(
+                    "tapret02Mq47rPbJsankXcDd3PDQaBhL1iDnELdqV6xz5eUiZVJYhLeVwu".to_string(),
+                ),
+            }
+        ],
+    }
 }


### PR DESCRIPTION
**Description**

This PR allow us use CRDT (automerge) strategy in `rgb_wallets` to avoid loose contract state in concurrency operations.

Now, transfers operations pull "a fork" of the `rgb_wallet` from carbonado server to use in client-side (wasm32) and push a merged version of the `rgb-wallet` to carbonado server.

**How it works**
We have two new methods: **retrieve_fork_wallets** and **store_fork_wallets**. The first method make  a copy of the wallet and the other method store the merged versoin of the wallet.

**Limitations**
- To use **automerge** in your project we need use to derive macros: Hydrate and Reconcile. Unfortunately, we use a lot of structs based in other crates, and it would take a while to add automerge in all dependencies. One workaround used was to create the "raw structs". This struct is similar to "DTO (Data Transfer Object)" pattern, allow us use the derives to work with automerge.  
- Today the implementation is limited to **RgbWallets**. I intend to extend this to Stock as well, but creating a DTO for this type of structure can be quite painful, as it is not clear how strict-types can interfere with this.
- Although the concurrency tests worked, I feel that we are not 100% sure about the solution, especially in high concurrency. To mitigate this, the rgb module was refactored to the "unit of work" pattern, to ensure that information persists only at the end of an operation. Another approach that we can use is to add cache in the files retrieval, of a few seconds, for the BME to get the "same" of the files.

By now, we use **automerge** and **autosurgeon** crates to handle the CRDT.

**Misc**
In the medium term, I intend to add this functionality directly to Stock, in rgb-wallet project, if I can combine with base58 (armored).


Closes #268

 