### PR TITLE
Add fee-rate support (RGB PSBT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitmask-core"
-version = "0.6.3-rc.20"
+version = "0.6.3-rc.21"
 dependencies = [
  "amplify",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmask-core"
-version = "0.6.3-rc.20"
+version = "0.6.3-rc.21"
 authors = [
     "Jose Diego Robles <jose@diba.io>",
     "Hunter Trujillo <hunter@diba.io>",

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -57,6 +57,8 @@ pub enum BitcoinError {
     /// Wrong Encrypted Descriptor Version
     #[error("Wrong Version: Encrypted descriptor is the wrong version. The version byte was: {0}")]
     WrongEncryptedDescriptorVersion(u8),
+    #[error("Wrong Descriptor: Wallet supports only taproot descriptor")]
+    WrongDescriptor,
     /// Upgrade unnecessary
     #[error("Descriptor does not need to be upgraded")]
     UpgradeUnnecessary,
@@ -296,13 +298,9 @@ pub async fn get_new_address(
     info!("get_new_address");
 
     let wallet = get_wallet(descriptor, change_descriptor).await?;
-    let address = wallet
-        .lock()
-        .await
-        .get_address(AddressIndex::New)?
-        .to_string();
+    let address = wallet.lock().await.get_address(AddressIndex::New)?;
     info!(format!("address: {address}"));
-    Ok(address)
+    Ok(address.to_string())
 }
 
 pub async fn validate_address(address: &Address) -> Result<(), BitcoinError> {

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -39,6 +39,9 @@ use crate::{
     trace,
 };
 
+// Minimum amount of satoshis to funding vault
+const MIN_FUNDS_SATS: u64 = 10000;
+
 impl SerdeEncryptSharedKey for DecryptedWalletData {
     type S = BincodeSerializer<Self>;
 }
@@ -65,6 +68,9 @@ pub enum BitcoinError {
     /// Wrong network
     #[error("Address provided is on the wrong network!")]
     WrongNetwork,
+    /// Wrong Encrypted Descriptor Format
+    #[error("Insufficient satoshis to create funding wallet. Minimum: {0} sats")]
+    InsufficientFundSats(u64),
     /// Drain wallet unable to finalize PSBT
     #[error("Drain wallet was unable to finalize PSBT")]
     DrainWalletUnfinalizedPsbt,
@@ -358,6 +364,14 @@ pub async fn fund_vault(
     uda_address_2: &str,
     fee_rate: Option<f32>,
 ) -> Result<FundVaultDetails, BitcoinError> {
+    let wallet = get_wallet(btc_descriptor_xprv, Some(btc_change_descriptor_xprv)).await?;
+    let fee_rate = fee_rate.map(FeeRate::from_sat_per_vb);
+
+    let balance = wallet.lock().await.get_balance()?;
+    if balance.confirmed < MIN_FUNDS_SATS {
+        return Err(BitcoinError::InsufficientFundSats(MIN_FUNDS_SATS));
+    };
+
     let assets_address_1 = Address::from_str(assets_address_1)?;
     let assets_address_2 = Address::from_str(assets_address_2)?;
     let uda_address_1 = Address::from_str(uda_address_1)?;
@@ -381,9 +395,6 @@ pub async fn fund_vault(
         address: uda_address_2,
         amount: rng.gen_range(600..1500),
     };
-
-    let wallet = get_wallet(btc_descriptor_xprv, Some(btc_change_descriptor_xprv)).await?;
-    let fee_rate = fee_rate.map(FeeRate::from_sat_per_vb);
 
     let asset_tx_details = create_transaction(
         vec![

--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -50,6 +50,7 @@ pub async fn create_transaction(
         for invoice in invoices {
             builder.add_recipient(invoice.address.script_pubkey(), invoice.amount);
         }
+
         builder.ordering(TxOrdering::Untouched); // TODO: Remove after implementing wallet persistence
         builder.enable_rbf().fee_rate(fee_rate.unwrap_or_default());
         builder.finish()?

--- a/src/bitcoin/psbt.rs
+++ b/src/bitcoin/psbt.rs
@@ -1,5 +1,5 @@
 use bdk::{blockchain::Blockchain, psbt::PsbtUtils, SignOptions, TransactionDetails};
-use bitcoin::{consensus::serialize, util::psbt::PartiallySignedTransaction};
+use bitcoin::{consensus::serialize, hashes::hex::ToHex, util::psbt::PartiallySignedTransaction};
 use thiserror::Error;
 
 use crate::{
@@ -35,7 +35,7 @@ pub async fn sign_psbt(
         debug!("Signed PSBT:", base64::encode(&serialize(&psbt)));
         let fee_amount = psbt.fee_amount().expect("fee amount on PSBT is known");
         let tx = psbt.extract_tx();
-        debug!("tx:", base64::encode(&serialize(&tx.clone())));
+        debug!("tx:", &serialize(&tx.clone()).to_hex());
         let blockchain = get_blockchain().await;
         blockchain.broadcast(&tx).await?;
 
@@ -105,7 +105,7 @@ pub async fn sign_psbt_with_multiple_wallets(
         debug!("Signed PSBT:", base64::encode(&serialize(&psbt)));
         let fee_amount = psbt.fee_amount().expect("fee amount on PSBT is known");
         let tx = psbt.extract_tx();
-        debug!("tx:", base64::encode(&serialize(&tx.clone())));
+        debug!("tx:", &serialize(&tx.clone()).to_hex());
         let blockchain = get_blockchain().await;
         blockchain.broadcast(&tx).await?;
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -466,6 +466,14 @@ pub enum TransferError {
     NoIface,
     /// FeeRate is supported in this operation. Please, use the absolute fee value.
     NoFeeRate,
+    /// Insufficient funds (expected: {input} sats / current: {output} sats)
+    Inflation {
+        /// Amount spent: input amounts
+        input: u64,
+
+        /// Amount sent: sum of output value + transaction fee
+        output: u64,
+    },
     /// Auto merge fail in this opration
     WrongAutoMerge(String),
     /// Occurs an error in create step. {0}

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -29,6 +29,7 @@ use crate::rgb::{
     prefetch::{
         prefetch_resolver_allocations, prefetch_resolver_user_utxo_status, prefetch_resolver_utxos,
     },
+    psbt::estimate_fee_tx,
     resolvers::ExplorerResolver,
     structs::AddressAmount,
     wallet::sync_wallet,
@@ -36,12 +37,24 @@ use crate::rgb::{
     TransferError,
 };
 
+use super::prefetch::prefetch_resolver_txs;
+
+pub const DUST_LIMIT_SATOSHI: u64 = 546;
+
 pub async fn prebuild_transfer_asset(
     request: FullRgbTransferRequest,
     stock: &mut Stock,
     rgb_wallet: &mut RgbWallet,
     resolver: &mut ExplorerResolver,
-) -> Result<(Vec<PsbtInputRequest>, Vec<PsbtInputRequest>, Vec<String>), TransferError> {
+) -> Result<
+    (
+        Vec<PsbtInputRequest>,
+        Vec<PsbtInputRequest>,
+        Vec<String>,
+        u64,
+    ),
+    TransferError,
+> {
     if let Err(err) = request.validate(&RGBContext::default()) {
         let errors = err
             .flatten()
@@ -83,7 +96,7 @@ pub async fn prebuild_transfer_asset(
         iface: iface_name,
         rgb_invoice: _,
         descriptor,
-        change_terminal: _,
+        change_terminal,
         fee,
         mut bitcoin_changes,
     } = request;
@@ -95,6 +108,7 @@ pub async fn prebuild_transfer_asset(
         AssetType::RGB21,
         AssetType::Contract,
         AssetType::Bitcoin,
+        AssetType::Change,
     ] {
         let contract_index = contract_type as u32;
         let terminal_step = format!("/{contract_index}/*");
@@ -103,6 +117,8 @@ pub async fn prebuild_transfer_asset(
             break;
         }
     }
+
+    let universal_desc = SecretString(universal_desc);
     let mut all_unspents = vec![];
 
     // Get All Assets UTXOs
@@ -120,7 +136,6 @@ pub async fn prebuild_transfer_asset(
         .map_err(|_| TransferError::NoContract)?;
 
     let contract_index = contract_index as u32;
-    prefetch_resolver_allocations(contract_iface, resolver).await;
     sync_wallet(contract_index, rgb_wallet, resolver);
     prefetch_resolver_utxos(
         contract_index,
@@ -129,6 +144,7 @@ pub async fn prebuild_transfer_asset(
         Some(RGB_DEFAULT_FETCH_LIMIT),
     )
     .await;
+    prefetch_resolver_allocations(contract_iface, resolver).await;
 
     let contract = export_contract(contract_id, stock, resolver, &mut Some(rgb_wallet.clone()))
         .map_err(TransferError::Export)?;
@@ -159,7 +175,7 @@ pub async fn prebuild_transfer_asset(
         .map_err(|_| TransferError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string())))?;
 
     let mut asset_total = 0;
-    let mut asset_inputs = vec![];
+    let mut assets_inputs = vec![];
     let mut rng = StdRng::from_entropy();
     let rnd_amount = rng.gen_range(600..1500);
 
@@ -172,17 +188,17 @@ pub async fn prebuild_transfer_asset(
                 }
 
                 let input = PsbtInputRequest {
-                    descriptor: SecretString(universal_desc.clone()),
+                    descriptor: universal_desc.clone(),
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation,
                     tapret: None,
                 };
-                if !asset_inputs
+                if !assets_inputs
                     .clone()
                     .into_iter()
                     .any(|x: PsbtInputRequest| x.utxo == alloc.utxo)
                 {
-                    asset_inputs.push(input);
+                    assets_inputs.push(input);
                     total_asset_bitcoin_unspend += asset_unspent_utxos
                         .clone()
                         .into_iter()
@@ -198,17 +214,17 @@ pub async fn prebuild_transfer_asset(
             }
             AllocationValue::UDA(_) => {
                 let input = PsbtInputRequest {
-                    descriptor: SecretString(universal_desc.clone()),
+                    descriptor: universal_desc.clone(),
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation,
                     tapret: None,
                 };
-                if !asset_inputs
+                if !assets_inputs
                     .clone()
                     .into_iter()
                     .any(|x| x.utxo == alloc.utxo)
                 {
-                    asset_inputs.push(input);
+                    assets_inputs.push(input);
                     total_asset_bitcoin_unspend += asset_unspent_utxos
                         .clone()
                         .into_iter()
@@ -235,70 +251,124 @@ pub async fn prebuild_transfer_asset(
         })
         .sum();
     let mut bitcoin_inputs = vec![];
-    if let PsbtFeeRequest::Value(fee_amount) = fee.clone() {
-        let bitcoin_indexes = [0, 1];
-        for bitcoin_index in bitcoin_indexes {
-            sync_wallet(bitcoin_index, rgb_wallet, resolver);
-            prefetch_resolver_utxos(
-                bitcoin_index,
-                rgb_wallet,
-                resolver,
-                Some(BITCOIN_DEFAULT_FETCH_LIMIT),
-            )
-            .await;
-            prefetch_resolver_user_utxo_status(bitcoin_index, rgb_wallet, resolver, false).await;
 
-            let mut unspent_utxos = next_utxos(bitcoin_index, rgb_wallet.clone(), resolver)
-                .map_err(|_| {
-                    TransferError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string()))
-                })?;
+    let bitcoin_indexes = [0, 1];
+    for bitcoin_index in bitcoin_indexes {
+        sync_wallet(bitcoin_index, rgb_wallet, resolver);
+        prefetch_resolver_utxos(
+            bitcoin_index,
+            rgb_wallet,
+            resolver,
+            Some(BITCOIN_DEFAULT_FETCH_LIMIT),
+        )
+        .await;
+        prefetch_resolver_user_utxo_status(bitcoin_index, rgb_wallet, resolver, false).await;
 
-            all_unspents.append(&mut unspent_utxos);
-        }
+        let mut unspent_utxos =
+            next_utxos(bitcoin_index, rgb_wallet.clone(), resolver).map_err(|_| {
+                TransferError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string()))
+            })?;
 
-        let mut bitcoin_total = total_asset_bitcoin_unspend;
-        for utxo in all_unspents {
-            if bitcoin_total > (fee_amount + rnd_amount) {
-                break;
-            } else {
-                bitcoin_total += utxo.amount;
-
-                let TerminalPath { app, index } = utxo.derivation.terminal;
-                let btc_input = PsbtInputRequest {
-                    descriptor: SecretString(universal_desc.clone()),
-                    utxo: utxo.outpoint.to_string(),
-                    utxo_terminal: format!("/{app}/{index}"),
-                    tapret: None,
-                };
-                if !bitcoin_inputs
-                    .clone()
-                    .into_iter()
-                    .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
-                {
-                    bitcoin_inputs.push(btc_input);
-                }
-            }
-        }
-        if bitcoin_total < (fee_amount + rnd_amount + total_bitcoin_spend) {
-            let mut errors = BTreeMap::new();
-            errors.insert("bitcoin".to_string(), "insufficient satoshis".to_string());
-            return Err(TransferError::Validation(errors));
-        } else {
-            let network = NETWORK.read().await.to_string();
-            let network = Network::from_str(&network)
-                .map_err(|err| TransferError::WrongNetwork(err.to_string()))?;
-
-            let network = AddressNetwork::from(network);
-
-            let change_address = get_address(1, 1, rgb_wallet.clone(), network)
-                .map_err(|err| TransferError::WrongNetwork(err.to_string()))?
-                .address;
-
-            let change_amount = bitcoin_total - (rnd_amount + fee_amount + total_bitcoin_spend);
-            let change_bitcoin = format!("{change_address}:{change_amount}");
-            bitcoin_changes.push(change_bitcoin);
-        }
+        all_unspents.append(&mut unspent_utxos);
     }
 
-    Ok((asset_inputs, bitcoin_inputs, bitcoin_changes))
+    let mut bitcoin_total = total_asset_bitcoin_unspend;
+    let (change_value, fee_value) = match fee.clone() {
+        PsbtFeeRequest::Value(fee_value) => {
+            let total_spendable = fee_value + rnd_amount + total_bitcoin_spend;
+            for utxo in all_unspents {
+                if bitcoin_total > total_spendable {
+                    break;
+                } else {
+                    let TerminalPath { app, index } = utxo.derivation.terminal;
+                    let btc_input = PsbtInputRequest {
+                        descriptor: universal_desc.clone(),
+                        utxo: utxo.outpoint.to_string(),
+                        utxo_terminal: format!("/{app}/{index}"),
+                        tapret: None,
+                    };
+                    if !bitcoin_inputs
+                        .clone()
+                        .into_iter()
+                        .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
+                    {
+                        bitcoin_inputs.push(btc_input);
+                        bitcoin_total += utxo.amount;
+                    }
+                }
+            }
+
+            let change_value = bitcoin_total - total_spendable;
+            (change_value, fee_value)
+        }
+        PsbtFeeRequest::FeeRate(fee_rate) => {
+            let total_spendable = rnd_amount + total_bitcoin_spend;
+            for utxo in all_unspents {
+                if bitcoin_total > total_spendable {
+                    break;
+                } else {
+                    let TerminalPath { app, index } = utxo.derivation.terminal;
+                    let btc_input = PsbtInputRequest {
+                        descriptor: universal_desc.clone(),
+                        utxo: utxo.outpoint.to_string(),
+                        utxo_terminal: format!("/{app}/{index}"),
+                        tapret: None,
+                    };
+                    if !bitcoin_inputs
+                        .clone()
+                        .into_iter()
+                        .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
+                    {
+                        bitcoin_inputs.push(btc_input);
+                        bitcoin_total += utxo.amount;
+                    }
+                }
+            }
+
+            let mut all_inputs = assets_inputs.clone();
+            all_inputs.extend(bitcoin_inputs.clone());
+
+            let txids = all_inputs
+                .clone()
+                .into_iter()
+                .map(|x| bitcoin::Txid::from_str(&x.utxo[..64]).expect("wrong txid"))
+                .collect();
+            prefetch_resolver_txs(txids, resolver).await;
+
+            let (change_value, fee) = estimate_fee_tx(
+                assets_inputs.clone(),
+                bitcoin_inputs.clone(),
+                bitcoin_changes.clone(),
+                fee_rate,
+                rgb_wallet,
+                Some(rnd_amount),
+                Some(change_terminal),
+                resolver,
+            )
+            .map_err(TransferError::Estimate)?;
+
+            (change_value, fee)
+        }
+    };
+
+    let total_spendable = fee_value + rnd_amount + total_bitcoin_spend;
+    if bitcoin_total < total_spendable {
+        let mut errors = BTreeMap::new();
+        errors.insert("bitcoin".to_string(), "insufficient satoshis".to_string());
+        return Err(TransferError::Validation(errors));
+    } else if change_value > 0 {
+        let network = NETWORK.read().await.to_string();
+        let network = Network::from_str(&network)
+            .map_err(|err| TransferError::WrongNetwork(err.to_string()))?;
+
+        let network = AddressNetwork::from(network);
+        let change_address = get_address(1, 0, rgb_wallet.clone(), network)
+            .map_err(|err| TransferError::WrongNetwork(err.to_string()))?
+            .address;
+
+        let change_bitcoin = format!("{change_address}:{change_value}");
+        bitcoin_changes.push(change_bitcoin);
+    }
+
+    Ok((assets_inputs, bitcoin_inputs, bitcoin_changes, fee_value))
 }

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -1,10 +1,7 @@
 use std::str::FromStr;
 
 use amplify::hex::{FromHex, ToHex};
-use bdk::{
-    wallet::coin_selection::{decide_change, Excess},
-    FeeRate,
-};
+use bdk::FeeRate;
 use bitcoin::{
     hashes::sha256,
     secp256k1::SECP256K1,
@@ -34,11 +31,16 @@ use wallet::{
 };
 
 use crate::{
+    info,
     rgb::{constants::RGB_PSBT_TAPRET, structs::AddressAmount},
-    structs::{AssetType, PsbtInputRequest, SecretString},
+    structs::{AssetType, PsbtInputRequest},
 };
 
 use crate::rgb::structs::AddressFormatParseError;
+
+// Base weight of a Txin, not counting the weight needed for satisfying it.
+// prev_txid (32 bytes) + prev_vout (4 bytes) + sequence (4 bytes)
+const TXIN_BASE_WEIGHT: usize = (32 + 4 + 4) * 4;
 
 #[derive(Clone, Eq, PartialEq, Debug, Display, Error, From)]
 #[display(doc_comments)]
@@ -70,8 +72,10 @@ pub enum PsbtInputError {
     WrongDerivation(String),
     /// The transaction is invalid: {0}
     WrongPrevOut(String),
-    /// The tweak is invalid: {0}
-    WrongTweak(String),
+    /// The input tweak is invalid: {0}
+    WrongInputTweak(String),
+    /// The watcher tweak is invalid: {0}
+    WrongWatcherTweak(String),
     /// The script is invalid: {0}
     WrongScript(String),
     /// The Input PSBT is invalid (Unexpected behavior).
@@ -102,6 +106,7 @@ pub fn create_psbt(
         AssetType::RGB21,
         AssetType::Contract,
         AssetType::Bitcoin,
+        AssetType::Change,
     ] {
         let contract_index = contract_type as u32;
         let terminal_step = format!("/{contract_index}/*");
@@ -116,43 +121,15 @@ pub fn create_psbt(
 
     // Define Input Descriptors
     for psbt_input in psbt_inputs {
-        let outpoint: OutPoint = psbt_input.utxo.parse().expect("invalid outpoint parse");
-        let mut input = InputDescriptor {
-            outpoint,
-            terminal: psbt_input
-                .utxo_terminal
-                .parse::<DerivationSubpath<UnhardenedIndex>>()
-                .map_err(CreatePsbtError::WrongTerminal)?,
-            seq_no: SeqNo::default(),
-            tweak: None,
-            sighash_type: EcdsaSighashType::All,
-        };
-
-        // Verify TapTweak (User Input or Watcher inspect)
-        if let Some(tapret) = psbt_input.tapret {
-            input.tweak = Some((
-                Fingerprint::default(),
-                tapret
-                    .parse::<sha256::Hash>()
-                    .map_err(|op| CreatePsbtError::WrongTapTweak(op.to_string()))?,
-            ))
-        } else if let Some(tweak) = complete_input_desc(
+        let new_input = InputDescriptor::resolve_psbt_input(
+            psbt_input,
             global_descriptor.clone(),
-            input.clone(),
             wallet.clone(),
             tx_resolver,
         )
-        .map_err(|op| CreatePsbtError::WrongTapTweak(op.to_string()))?
-        {
-            input.tweak = Some((
-                Fingerprint::default(),
-                tweak
-                    .parse::<sha256::Hash>()
-                    .map_err(|op| CreatePsbtError::WrongTapTweak(op.to_string()))?,
-            ))
-        }
+        .map_err(CreatePsbtError::WrongInput)?;
 
-        inputs.push(input);
+        inputs.push(new_input);
     }
 
     let bitcoin_addresses: Vec<AddressAmount> = psbt_outputs
@@ -234,101 +211,6 @@ pub fn create_psbt(
     Ok((psbt, change_index.to_string()))
 }
 
-fn complete_input_desc(
-    descriptor: Descriptor<DerivationAccount>,
-    input: InputDescriptor,
-    wallet: Option<RgbWallet>,
-    tx_resolver: &impl ResolveTx,
-) -> Result<Option<String>, PsbtInputError> {
-    let txid = input.outpoint.txid;
-    let tx = tx_resolver
-        .resolve_tx(txid)
-        .map_err(|op| PsbtInputError::WrongPrevOut(op.to_string()))?;
-    let prev_output = tx.output.get(input.outpoint.vout as usize).unwrap();
-
-    let mut scripts = bmap![];
-    if let Descriptor::Tr(_) = descriptor {
-        let output_descriptor = DeriveDescriptor::<XOnlyPublicKey>::derive_descriptor(
-            &descriptor,
-            SECP256K1,
-            &input.terminal,
-        )
-        .map_err(|op| PsbtInputError::WrongDerivation(op.to_string()))?;
-
-        scripts.insert(output_descriptor.script_pubkey(), None);
-        if let Some(walet) = wallet {
-            let RgbDescr::Tapret(tapret_desc) = walet.descr;
-
-            let idx = match input.terminal.first() {
-                Some(idx) => idx,
-                _ => return Err(PsbtInputError::WrongTerminal),
-            };
-            let contract_index =
-                u32::from_str(&idx.to_string()).map_err(|_| PsbtInputError::WrongTerminal)?;
-
-            let idx = match input.terminal.last() {
-                Some(idx) => idx,
-                _ => return Err(PsbtInputError::WrongTerminal),
-            };
-            let change_index =
-                u32::from_str(&idx.to_string()).map_err(|_| PsbtInputError::WrongTerminal)?;
-
-            let terminal = TerminalPath {
-                app: contract_index,
-                index: change_index,
-            };
-
-            if let Some(taprets) = tapret_desc.taprets.get(&terminal) {
-                for tweak in taprets {
-                    if let Descriptor::<XOnlyPublicKey>::Tr(tr_desc) = &output_descriptor {
-                        let xonly = tr_desc.internal_key();
-
-                        let tap_tweak = ScriptBuf::from_bytes(TapScript::commit(tweak).to_vec());
-
-                        if let Ok(tap_builder) = TaprootBuilder::with_capacity(1)
-                            .add_leaf(0, tap_tweak)
-                            .map_err(|op| PsbtInputError::WrongTweak(op.to_string()))
-                        {
-                            // TODO: Incompatible versions between RGB and Descriptor Wallet
-                            let xonly_30 =
-                                bitcoin_30::secp256k1::XOnlyPublicKey::from_str(&xonly.to_hex())
-                                    .map_err(|op| PsbtInputError::WrongTweak(op.to_string()))?;
-
-                            let spent_info =
-                                tap_builder.finalize(SECP256K1_30, xonly_30).map_err(|_| {
-                                    PsbtInputError::WrongTweak("incomplete tree".to_string())
-                                })?;
-
-                            if let Some(merkle_root) = spent_info.merkle_root() {
-                                let tap_script = ScriptBuf::new_v1_p2tr(
-                                    SECP256K1_30,
-                                    xonly_30,
-                                    Some(merkle_root),
-                                );
-
-                                let spk = Script::from_str(&tap_script.as_script().to_hex())
-                                    .map_err(|op| PsbtInputError::WrongTweak(op.to_string()))?;
-                                scripts.insert(spk, Some(merkle_root.to_hex()));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    };
-
-    if let Some((_, scp)) = scripts
-        .into_iter()
-        .find(|(sc, _)| sc.clone() == prev_output.script_pubkey)
-    {
-        Ok(scp)
-    } else {
-        Err(PsbtInputError::WrongScript(
-            "derived scriptPubkey does not match transaction scriptPubkey".to_string(),
-        ))
-    }
-}
-
 pub fn extract_commit(psbt: Psbt) -> Result<(Outpoint, Vec<u8>), DbcPsbtError> {
     let (index, output) = psbt
         .outputs
@@ -392,95 +274,297 @@ pub fn save_commit(outpoint: Outpoint, commit: Vec<u8>, terminal: &str, wallet: 
     wallet.descr = RgbDescr::Tapret(tapret);
 }
 
-// TODO: [Experimental] Review with Diba Team
-pub fn fee_estimate<T>(
+#[derive(Clone, Eq, PartialEq, Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub enum EstimateFeeError {
+    /// Invalid address. {0:?}
+    WrongAddress(AddressFormatParseError),
+    /// The Input PSBT is invalid. {0}
+    WrongPsbtInput(PsbtInputError),
+    /// Invalid descriptor. '{0}'
+    WrongDescriptor(String),
+    /// Invalid terminal change. '{0}'
+    WrongTerminal(String),
+    /// The Pre-PSBT is invalid. {0}
+    PreBuildFail(String),
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn estimate_fee_tx<T>(
     assets_inputs: Vec<PsbtInputRequest>,
-    asset_descriptor_change: Option<SecretString>,
-    asset_terminal_change: Option<String>,
     bitcoin_inputs: Vec<PsbtInputRequest>,
     bitcoin_changes: Vec<String>,
     fee_rate: f32,
+    wallet: &mut RgbWallet,
+    amount_change: Option<u64>,
+    terminal_change: Option<String>,
     resolver: &mut T,
-) -> u64
+) -> Result<(u64, u64), EstimateFeeError>
 where
     T: ResolveTx + Resolver,
 {
-    let mut vout_value = 0;
+    // Define Feerate
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate);
+    let mut psbt_inputs = assets_inputs.clone();
+    psbt_inputs.extend(bitcoin_inputs);
 
-    // Total Stats
-    let mut all_inputs = assets_inputs;
-    all_inputs.extend(bitcoin_inputs);
+    // Define "Universal" Descriptor
+    let psbt_input = assets_inputs[0].clone();
+    let wildcard_terminal = "/*/*";
+    let mut descriptor_pub = psbt_input.descriptor.to_string();
+    for contract_type in [
+        AssetType::RGB20,
+        AssetType::RGB21,
+        AssetType::Contract,
+        AssetType::Bitcoin,
+        AssetType::Change,
+    ] {
+        let contract_index = contract_type as u32;
+        let terminal_step = format!("/{contract_index}/*");
+        if descriptor_pub.contains(&terminal_step) {
+            descriptor_pub = descriptor_pub.replace(&terminal_step, wildcard_terminal);
+            break;
+        }
+    }
 
-    for item in all_inputs {
-        let outpoint = OutPoint::from_str(&item.utxo).expect("invalid outpoint");
+    // Total Inputs
+    let mut psbt_inputs_total = 0;
+    for psbt_input in psbt_inputs.clone() {
+        let outpoint = OutPoint::from_str(&psbt_input.utxo).expect("invalid outpoint");
         if let Ok(tx) = resolver.resolve_tx(outpoint.txid) {
             if let Some(vout) = tx.output.to_vec().get(outpoint.vout as usize) {
-                vout_value = vout.value;
+                psbt_inputs_total = vout.value;
             }
         }
     }
 
-    // Other Recipient
-    let mut total_spent = 0;
+    // Total Output
+    let mut total_psbt_output = 0;
+    let mut bitcoin_addresses: Vec<AddressAmount> = vec![];
     for bitcoin_change in bitcoin_changes {
         let recipient =
-            AddressAmount::from_str(&bitcoin_change).expect("invalid address amount format");
-        total_spent += recipient.amount;
+            AddressAmount::from_str(&bitcoin_change).map_err(EstimateFeeError::WrongAddress)?;
+        total_psbt_output += recipient.amount;
+        bitcoin_addresses.push(recipient);
     }
 
-    // Main Recipient
-    total_spent = vout_value - total_spent;
-    let target_script = get_recipient_script(asset_descriptor_change, asset_terminal_change)
-        .expect("invalid derivation");
+    let change = psbt_inputs_total - total_psbt_output - amount_change.unwrap_or_default();
 
-    let excess = decide_change(total_spent, fee_rate, &target_script);
-    match excess {
-        Excess::Change { amount: _, fee } => fee,
-        Excess::NoChange {
-            dust_threshold: _,
-            remaining_amount: _,
-            change_fee,
-        } => change_fee,
+    // Pre-build PSBT
+    let global_descriptor: Descriptor<DerivationAccount> = Descriptor::from_str(&descriptor_pub)
+        .map_err(|op| CreatePsbtError::WrongDescriptor(op.to_string()))
+        .map_err(|op| EstimateFeeError::WrongDescriptor(op.to_string()))?;
+
+    let mut inputs = vec![];
+    for psbt_input in psbt_inputs {
+        let new_input = InputDescriptor::resolve_psbt_input(
+            psbt_input,
+            global_descriptor.clone(),
+            Some(wallet.clone()),
+            resolver,
+        )
+        .map_err(EstimateFeeError::WrongPsbtInput)?;
+        inputs.push(new_input);
+    }
+
+    let outputs: Vec<(PubkeyScript, u64)> = bitcoin_addresses
+        .into_iter()
+        .map(|AddressAmount { address, amount }| (address.script_pubkey().into(), amount))
+        .collect();
+
+    let mut change_index = DerivationSubpath::new();
+    if let Some(terminal_change) = terminal_change {
+        change_index = terminal_change
+            .parse::<DerivationSubpath<UnhardenedIndex>>()
+            .map_err(|op| EstimateFeeError::WrongTerminal(op.to_string()))?;
+    }
+
+    let pre_psbt = Psbt::construct(
+        &global_descriptor,
+        &inputs,
+        &outputs,
+        change_index.to_vec(),
+        0,
+        resolver,
+    )
+    .map_err(|op| EstimateFeeError::PreBuildFail(op.to_string()))?;
+
+    // Over-simplification of bdk fee calculation:
+    // https://github.com/bitcoindevkit/bdk/blob/2867e88b64b4a8cf7136cc562ec61c077737a087/crates/bdk/src/wallet/mod.rs#L1009-L1131
+    // https://github.com/bitcoindevkit/bdk/blob/2867e88b64b4a8cf7136cc562ec61c077737a087/crates/bdk/src/wallet/coin_selection.rs#L398-L630
+    let mut fee = fee_rate.fee_wu(pre_psbt.to_unsigned_tx().weight());
+    fee += fee_rate.fee_wu(2);
+    fee += fee_rate.fee_wu(
+        (TXIN_BASE_WEIGHT
+            + global_descriptor
+                .max_satisfaction_weight()
+                .unwrap_or_default())
+            * inputs.len(),
+    );
+
+    info!(format!(
+        "Remaining/Change (Fee): {change}/{} ({fee})",
+        amount_change.unwrap_or_default()
+    ));
+
+    Ok((change - fee, fee))
+}
+
+pub trait PsbtInputEx<T> {
+    type Error: std::error::Error;
+
+    fn resolve_psbt_input(
+        psbt_input: PsbtInputRequest,
+        descriptor: Descriptor<DerivationAccount>,
+        wallet: Option<RgbWallet>,
+        tx_resolver: &impl ResolveTx,
+    ) -> Result<T, Self::Error>;
+}
+
+impl PsbtInputEx<InputDescriptor> for InputDescriptor {
+    type Error = PsbtInputError;
+
+    fn resolve_psbt_input(
+        psbt_input: PsbtInputRequest,
+        descriptor: Descriptor<DerivationAccount>,
+        wallet: Option<RgbWallet>,
+        tx_resolver: &impl ResolveTx,
+    ) -> Result<Self, Self::Error> {
+        let outpoint: OutPoint = psbt_input.utxo.parse().expect("invalid outpoint parse");
+        let mut input: InputDescriptor = InputDescriptor {
+            outpoint,
+            terminal: psbt_input
+                .utxo_terminal
+                .parse::<DerivationSubpath<UnhardenedIndex>>()
+                .map_err(|_| PsbtInputError::WrongTerminal)?,
+            seq_no: SeqNo::default(),
+            tweak: None,
+            sighash_type: EcdsaSighashType::All,
+        };
+
+        // Verify TapTweak (User Input or Watcher inspect)
+        if let Some(tapret) = psbt_input.tapret {
+            input.tweak = Some((
+                Fingerprint::default(),
+                tapret
+                    .parse::<sha256::Hash>()
+                    .map_err(|op| PsbtInputError::WrongInputTweak(op.to_string()))?,
+            ))
+        } else if let Some(tweak) = complete_input_desc(
+            descriptor.clone(),
+            input.clone(),
+            wallet.clone(),
+            tx_resolver,
+        )
+        .map_err(|op| PsbtInputError::WrongWatcherTweak(op.to_string()))?
+        {
+            input.tweak = Some((
+                Fingerprint::default(),
+                tweak
+                    .parse::<sha256::Hash>()
+                    .map_err(|op| PsbtInputError::WrongWatcherTweak(op.to_string()))?,
+            ))
+        }
+
+        Ok(input)
     }
 }
 
-fn get_recipient_script(
-    descriptor_pub: Option<SecretString>,
-    bitcoin_terminal: Option<String>,
-) -> Option<Script> {
-    let (terminal, terminal_path) = match bitcoin_terminal {
-        Some(bitcoin_terminal) => (
-            bitcoin_terminal.clone(),
-            bitcoin_terminal
-                .parse()
-                .expect("invalid terminal path parse"),
-        ),
-        None => ("/0/1".to_string(), DerivationSubpath::new()),
+fn complete_input_desc(
+    descriptor: Descriptor<DerivationAccount>,
+    input: InputDescriptor,
+    wallet: Option<RgbWallet>,
+    tx_resolver: &impl ResolveTx,
+) -> Result<Option<String>, PsbtInputError> {
+    let txid = input.outpoint.txid;
+    let tx = tx_resolver
+        .resolve_tx(txid)
+        .map_err(|op| PsbtInputError::WrongPrevOut(op.to_string()))?;
+    let prev_output = tx.output.get(input.outpoint.vout as usize).unwrap();
+
+    let mut scripts = bmap![];
+    if let Descriptor::Tr(_) = descriptor {
+        let output_descriptor = DeriveDescriptor::<XOnlyPublicKey>::derive_descriptor(
+            &descriptor,
+            SECP256K1,
+            &input.terminal,
+        )
+        .map_err(|op| PsbtInputError::WrongDerivation(op.to_string()))?;
+
+        scripts.insert(output_descriptor.script_pubkey(), None);
+        if let Some(walet) = wallet {
+            let RgbDescr::Tapret(tapret_desc) = walet.descr;
+
+            let idx = match input.terminal.first() {
+                Some(idx) => idx,
+                _ => return Err(PsbtInputError::WrongTerminal),
+            };
+            let contract_index =
+                u32::from_str(&idx.to_string()).map_err(|_| PsbtInputError::WrongTerminal)?;
+
+            let idx = match input.terminal.last() {
+                Some(idx) => idx,
+                _ => return Err(PsbtInputError::WrongTerminal),
+            };
+            let change_index =
+                u32::from_str(&idx.to_string()).map_err(|_| PsbtInputError::WrongTerminal)?;
+
+            let terminal = TerminalPath {
+                app: contract_index,
+                index: change_index,
+            };
+
+            if let Some(taprets) = tapret_desc.taprets.get(&terminal) {
+                for tweak in taprets {
+                    if let Descriptor::<XOnlyPublicKey>::Tr(tr_desc) = &output_descriptor {
+                        let xonly = tr_desc.internal_key();
+
+                        let tap_tweak = ScriptBuf::from_bytes(TapScript::commit(tweak).to_vec());
+
+                        if let Ok(tap_builder) = TaprootBuilder::with_capacity(1)
+                            .add_leaf(0, tap_tweak)
+                            .map_err(|op| PsbtInputError::WrongWatcherTweak(op.to_string()))
+                        {
+                            // TODO: Incompatible versions between RGB and Descriptor Wallet
+                            let xonly_30 =
+                                bitcoin_30::secp256k1::XOnlyPublicKey::from_str(&xonly.to_hex())
+                                    .map_err(|op| {
+                                        PsbtInputError::WrongWatcherTweak(op.to_string())
+                                    })?;
+
+                            let spent_info =
+                                tap_builder.finalize(SECP256K1_30, xonly_30).map_err(|_| {
+                                    PsbtInputError::WrongWatcherTweak("incomplete tree".to_string())
+                                })?;
+
+                            if let Some(merkle_root) = spent_info.merkle_root() {
+                                let tap_script = ScriptBuf::new_v1_p2tr(
+                                    SECP256K1_30,
+                                    xonly_30,
+                                    Some(merkle_root),
+                                );
+
+                                let spk = Script::from_str(&tap_script.as_script().to_hex())
+                                    .map_err(|op| {
+                                        PsbtInputError::WrongWatcherTweak(op.to_string())
+                                    })?;
+                                scripts.insert(spk, Some(merkle_root.to_hex()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
     };
 
-    if let Some(descriptor_pub) = descriptor_pub {
-        let descriptor_pub = descriptor_pub.to_string().replace(&terminal, "/*/*");
-        let descriptor: &Descriptor<DerivationAccount> =
-            &Descriptor::from_str(&descriptor_pub).expect("invalid descriptor parse");
-
-        match descriptor {
-            Descriptor::Tr(_) => {
-                let change_descriptor = DeriveDescriptor::<XOnlyPublicKey>::derive_descriptor(
-                    descriptor,
-                    SECP256K1,
-                    terminal_path,
-                )
-                .expect("Derivation mismatch");
-                let change_descriptor = match change_descriptor {
-                    Descriptor::Tr(tr) => tr,
-                    _ => unreachable!(),
-                };
-                Some(change_descriptor.script_pubkey())
-            }
-            _ => None,
-        }
+    if let Some((_, scp)) = scripts
+        .into_iter()
+        .find(|(sc, _)| sc.clone() == prev_output.script_pubkey)
+    {
+        Ok(scp)
     } else {
-        None
+        Err(PsbtInputError::WrongScript(
+            "derived scriptPubkey does not match transaction scriptPubkey".to_string(),
+        ))
     }
 }

--- a/src/rgb/wallet.rs
+++ b/src/rgb/wallet.rs
@@ -85,6 +85,7 @@ pub fn get_address(
     wallet: RgbWallet,
     network: AddressNetwork,
 ) -> Result<AddressTerminal, anyhow::Error> {
+    let index = index + 1;
     let scripts = wallet.descr.derive(iface_index, 0..index);
     let addresses: Vec<AddressTerminal> = scripts
         .into_iter()
@@ -219,9 +220,7 @@ pub fn sync_wallet(iface_index: u32, wallet: &mut RgbWallet, resolver: &mut impl
     let step = 20;
     let index = 0;
 
-    let scripts = wallet.descr.derive(iface_index, index..step);
-    let new_scripts = scripts.into_iter().map(|(d, sc)| (d, sc)).collect();
-
+    let new_scripts = wallet.descr.derive(iface_index, index..step);
     let new_utxos = resolver
         .resolve_utxo(new_scripts)
         .expect("service unavalible");
@@ -273,7 +272,7 @@ where
 
     if let Some((d, sc)) = script {
         let mut scripts = BTreeMap::new();
-        scripts.insert(d, sc);
+        scripts.insert(d.clone(), sc);
 
         let new_utxos = &resolver.resolve_utxo(scripts).expect("service unavalible");
         for utxo in new_utxos {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -318,8 +318,10 @@ pub struct ReIssueResponse {
 pub enum AssetType {
     #[serde(rename = "bitcoin")]
     Bitcoin = 0,
+    #[serde(rename = "change")]
+    Change = 1,
     #[serde(rename = "contract")]
-    Contract = 9,
+    Contract = 10,
     #[serde(rename = "rgb20")]
     RGB20 = 20,
     #[serde(rename = "rgb21")]

--- a/tests/rgb/integration/dustless.rs
+++ b/tests/rgb/integration/dustless.rs
@@ -5,13 +5,19 @@ use crate::rgb::integration::utils::{
 };
 use bdk::wallet::AddressIndex;
 use bitmask_core::{
-    bitcoin::{get_wallet, save_mnemonic, sign_psbt_file, sync_wallet},
-    rgb::{accept_transfer, get_contract},
-    structs::{AcceptRequest, PsbtInputRequest, SecretString, SignPsbtRequest},
+    bitcoin::{
+        fund_vault, get_new_address, get_wallet, new_mnemonic, save_mnemonic, sign_psbt_file,
+        sync_wallet,
+    },
+    rgb::{accept_transfer, create_watcher, full_transfer_asset, get_contract},
+    structs::{
+        AcceptRequest, FullRgbTransferRequest, PsbtFeeRequest, PsbtInputRequest, SecretString,
+        SignPsbtRequest, WatcherRequest,
+    },
 };
 
 #[tokio::test]
-async fn allow_multiple_inputs_in_same_psbt() -> anyhow::Result<()> {
+async fn create_dustless_transfer_with_fee_value() -> anyhow::Result<()> {
     // 1. Initial Setup
     let issuer_keys = save_mnemonic(
         &SecretString(ISSUER_MNEMONIC.to_string()),
@@ -23,6 +29,7 @@ async fn allow_multiple_inputs_in_same_psbt() -> anyhow::Result<()> {
         &SecretString("".to_string()),
     )
     .await?;
+
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
@@ -98,6 +105,142 @@ async fn allow_multiple_inputs_in_same_psbt() -> anyhow::Result<()> {
         descriptors: [
             SecretString(issuer_keys.private.rgb_assets_descriptor_xprv.clone()),
             SecretString(issuer_keys.private.btc_descriptor_xprv.clone()),
+        ]
+        .to_vec(),
+    };
+    let resp = sign_psbt_file(request).await;
+    assert!(resp.is_ok());
+
+    let request = AcceptRequest {
+        consignment: transfer_resp.consig.clone(),
+        force: false,
+    };
+
+    let resp = accept_transfer(&sk, request).await;
+    assert!(resp.is_ok());
+    assert!(resp?.valid);
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_dustless_transfer_with_fee_rate() -> anyhow::Result<()> {
+    // 1. Initial Setup
+    let issuer_keys = new_mnemonic(&SecretString("".to_string())).await?;
+    let owner_keys = new_mnemonic(&SecretString("".to_string())).await?;
+
+    // Create Watcher
+    let watcher_name = "default";
+    let issuer_sk = &issuer_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: issuer_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+
+    create_watcher(issuer_sk, create_watch_req.clone()).await?;
+
+    let btc_address_1 = get_new_address(
+        &SecretString(issuer_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let btc_address_2 = get_new_address(
+        &SecretString(owner_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.0001";
+    send_some_coins(&btc_address_1, default_coins).await;
+
+    let btc_descriptor_xprv = SecretString(issuer_keys.private.btc_descriptor_xprv.clone());
+    let btc_change_descriptor_xprv =
+        SecretString(issuer_keys.private.btc_change_descriptor_xprv.clone());
+
+    let assets_address_1 = get_new_address(
+        &SecretString(issuer_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let assets_address_2 = get_new_address(
+        &SecretString(issuer_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_1 = get_new_address(
+        &SecretString(issuer_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_2 = get_new_address(
+        &SecretString(issuer_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let btc_wallet = get_wallet(&btc_descriptor_xprv, Some(&btc_change_descriptor_xprv)).await?;
+    sync_wallet(&btc_wallet).await?;
+
+    let fund_vault = fund_vault(
+        &btc_descriptor_xprv,
+        &btc_change_descriptor_xprv,
+        &assets_address_1,
+        &assets_address_2,
+        &uda_address_1,
+        &uda_address_2,
+        Some(1.1),
+    )
+    .await?;
+
+    send_some_coins(&btc_address_2, default_coins).await;
+
+    let issuer_resp = issuer_issue_contract_v2(
+        1,
+        "RGB20",
+        5,
+        false,
+        false,
+        None,
+        None,
+        Some(UtxoFilter::with_outpoint(
+            fund_vault.assets_output.unwrap_or_default(),
+        )),
+        Some(issuer_keys.clone()),
+    )
+    .await?;
+    let issuer_resp = issuer_resp[0].clone();
+    let owner_resp = &create_new_invoice(
+        &issuer_resp.contract_id,
+        &issuer_resp.iface,
+        1,
+        owner_keys.clone(),
+        None,
+        Some(issuer_resp.clone().contract.strict),
+    )
+    .await?;
+
+    let sk = issuer_keys.private.nostr_prv.to_string();
+    let request = FullRgbTransferRequest {
+        contract_id: issuer_resp.contract_id,
+        iface: issuer_resp.iface,
+        rgb_invoice: owner_resp.invoice.to_string(),
+        descriptor: SecretString(issuer_keys.public.rgb_assets_descriptor_xpub.to_string()),
+        change_terminal: "/20/1".to_string(),
+        fee: PsbtFeeRequest::FeeRate(2.1),
+        bitcoin_changes: vec![],
+    };
+
+    let transfer_resp = full_transfer_asset(&sk, request).await?;
+    let request = SignPsbtRequest {
+        psbt: transfer_resp.psbt.clone(),
+        descriptors: [
+            SecretString(issuer_keys.private.rgb_assets_descriptor_xprv.clone()),
+            SecretString(issuer_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(issuer_keys.private.btc_change_descriptor_xprv.clone()),
         ]
         .to_vec(),
     };

--- a/tests/rgb/integration/transfers.rs
+++ b/tests/rgb/integration/transfers.rs
@@ -1969,7 +1969,6 @@ async fn allow_consecutive_full_transfer_bidirectional() -> anyhow::Result<()> {
             ],
         };
         let resp = sign_psbt_file(request).await;
-        // println!("{:#?}", resp);
         assert!(resp.is_ok());
 
         let request = AcceptRequest {
@@ -2033,7 +2032,6 @@ async fn allow_consecutive_full_transfer_bidirectional() -> anyhow::Result<()> {
                 ],
             };
             let resp = sign_psbt_file(request).await;
-            // println!("{:#?}", resp);
             assert!(resp.is_ok());
 
             let request = AcceptRequest {

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -61,7 +61,7 @@ impl TransferRounds {
 
 #[wasm_bindgen_test]
 #[allow(unused_assignments)]
-async fn create_contract_and_transfer() {
+async fn create_transfer_with_fee_value() {
     set_panic_hook();
     // let issuer_mnemonic =
     //     "try engine hurt mushroom adapt club boring diagram barely rail cable vicious tower boss hurt";
@@ -293,6 +293,294 @@ async fn create_contract_and_transfer() {
             descriptor: SecretString(sender_desc.to_string()),
             change_terminal: "/20/1".to_string(),
             fee: PsbtFeeRequest::Value(1000),
+            bitcoin_changes: vec![],
+        };
+
+        let full_transfer_req = serde_wasm_bindgen::to_value(&full_transfer_req).expect("");
+        let full_transfer_resp: JsValue = resolve(full_transfer_asset(
+            sender_sk.to_string(),
+            full_transfer_req,
+        ))
+        .await;
+        let full_transfer_resp: RgbTransferResponse = json_parse(&full_transfer_resp);
+        debug!(format!(
+            "Payment ({sender}): {:?}",
+            full_transfer_resp.consig_id
+        ));
+
+        info!(format!("Sign PSBT ({sender})"));
+        let psbt_req = SignPsbtRequest {
+            psbt: full_transfer_resp.psbt,
+            descriptors: sender_keys,
+        };
+
+        let psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
+        let psbt_resp: JsValue = resolve(psbt_sign_file(sender_sk.to_string(), psbt_req)).await;
+        let psbt_resp: SignPsbtResponse = json_parse(&psbt_resp);
+        debug!(format!("Sign Psbt: {:?}", psbt_resp));
+
+        info!("Create new Block");
+        let resp = new_block().await;
+        debug!(format!("Block Created: {:?}", resp));
+
+        info!(format!("Save Consig ({receiver})"));
+        let save_transfer_req = RgbSaveTransferRequest {
+            iface: issuer_resp.iface.clone(),
+            consignment: full_transfer_resp.consig.clone(),
+        };
+        let save_transfer_req = serde_wasm_bindgen::to_value(&save_transfer_req).expect("");
+        let save_transfer_resp =
+            resolve(save_transfer(receiver_sk.to_string(), save_transfer_req)).await;
+        let save_transfer_resp: RgbTransferStatusResponse = json_parse(&save_transfer_resp);
+        debug!(format!("Save Consig: {:?}", save_transfer_resp));
+
+        info!("Verify Consig (Both)");
+        let verify_transfer_resp = resolve(verify_transfers(sender_sk.to_string())).await;
+        let verify_transfer_resp: BatchRgbTransferResponse = json_parse(&verify_transfer_resp);
+        debug!(format!(
+            "Verify Consig ({sender}): {:?}",
+            verify_transfer_resp
+        ));
+
+        let verify_transfer_resp = resolve(verify_transfers(receiver_sk.to_string())).await;
+        let verify_transfer_resp: BatchRgbTransferResponse = json_parse(&verify_transfer_resp);
+        debug!(format!(
+            "Verify Consig ({receiver}): {:?}",
+            verify_transfer_resp
+        ));
+
+        let (sender_balance, receiver_balance) = if round.is_issuer_sender {
+            total_issuer -= round.send_amount;
+            total_owner += round.send_amount;
+            (total_issuer, total_owner)
+        } else {
+            total_issuer += round.send_amount;
+            total_owner -= round.send_amount;
+            (total_owner, total_issuer)
+        };
+
+        info!(format!("Get Contract Balancer ({sender})"));
+        let contract_resp = resolve(get_contract(
+            sender_sk.to_string(),
+            issuer_resp.contract_id.clone(),
+        ))
+        .await;
+        let contract_resp: ContractResponse = json_parse(&contract_resp);
+        debug!(format!(
+            "Contract ({sender}): {} ({})\n {:#?}",
+            contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
+        ));
+        let sender_current_balance = contract_resp.balance;
+
+        info!(format!("Get Contract Balancer ({receiver})"));
+        let contract_resp = resolve(get_contract(
+            receiver_sk.to_string(),
+            issuer_resp.contract_id.clone(),
+        ))
+        .await;
+        let contract_resp: ContractResponse = json_parse(&contract_resp);
+        debug!(format!(
+            "Contract ({receiver}): {} ({})\n {:#?}",
+            contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
+        ));
+        let receiver_current_balance = contract_resp.balance;
+
+        info!(format!("<<<< ROUND #{index} Finish >>>>"));
+        assert_eq!(sender_current_balance, sender_balance);
+        assert_eq!(receiver_current_balance, receiver_balance);
+    }
+}
+
+#[wasm_bindgen_test]
+#[allow(unused_assignments)]
+async fn create_transfer_with_fee_rate() {
+    set_panic_hook();
+    let issuer_vault = resolve(new_mnemonic("".to_string())).await;
+    let issuer_vault: DecryptedWalletData = json_parse(&issuer_vault);
+    let owner_vault = resolve(new_mnemonic("".to_string())).await;
+    let owner_vault: DecryptedWalletData = json_parse(&owner_vault);
+
+    info!("Create Issuer Watcher");
+    let iface = "RGB20";
+    let watcher_name = "default";
+    let issuer_watcher_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: issuer_vault.public.watcher_xpub.clone(),
+        force: false,
+    };
+
+    let issuer_sk = &issuer_vault.private.nostr_prv;
+    let issuer_watcher_req = serde_wasm_bindgen::to_value(&issuer_watcher_req).expect("");
+    let watcher_resp: JsValue = resolve(create_watcher(
+        issuer_sk.clone(),
+        issuer_watcher_req.clone(),
+    ))
+    .await;
+    let watcher_resp: WatcherResponse = json_parse(&watcher_resp);
+
+    info!("Get Address");
+    let next_address: JsValue = resolve(watcher_next_address(
+        issuer_sk.clone(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let issuer_next_address: NextAddressResponse = json_parse(&next_address);
+    debug!(format!(
+        "Issuer Show Address {}",
+        issuer_next_address.address
+    ));
+    let resp = send_coins(&issuer_next_address.address, "0.00010000").await;
+    debug!(format!("Issuer Receive Bitcoin {:?}", resp));
+
+    info!("Create Owner Watcher");
+    let owner_watcher_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: owner_vault.public.watcher_xpub.clone(),
+        force: false,
+    };
+    let owner_sk = &owner_vault.private.nostr_prv;
+    let owner_watcher_req = serde_wasm_bindgen::to_value(&owner_watcher_req).expect("");
+    let watcher_resp: JsValue = resolve(create_watcher(
+        owner_sk.to_string(),
+        owner_watcher_req.clone(),
+    ))
+    .await;
+    let watcher_resp: WatcherResponse = json_parse(&watcher_resp);
+
+    info!("Get Address");
+    let owner_next_address: JsValue = resolve(watcher_next_address(
+        owner_sk.to_string(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let owner_next_address: NextAddressResponse = json_parse(&owner_next_address);
+    debug!(format!("Owner Show Address {}", owner_next_address.address));
+    let resp = send_coins(&owner_next_address.address, "1").await;
+    debug!(format!("Owner Receive Bitcoin {:?}", resp));
+
+    info!("Get UTXO (Owner)");
+    let next_utxo: JsValue = resolve(watcher_next_utxo(
+        owner_sk.clone(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let owner_next_utxo: NextUtxoResponse = json_parse(&next_utxo);
+
+    info!("Get UTXO (Issuer)");
+    let next_utxo: JsValue = resolve(watcher_next_utxo(
+        issuer_sk.clone(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let issuer_next_utxo: NextUtxoResponse = json_parse(&next_utxo);
+
+    assert!(issuer_next_utxo.utxo.is_some());
+    assert!(owner_next_utxo.utxo.is_some());
+
+    info!("Create Contract (Issuer)");
+    let supply = 100_000;
+    let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
+    let issue_seal = format!("tapret1st:{issue_utxo}");
+    let issue_req = IssueRequest {
+        ticker: "DIBA".to_string(),
+        name: "DIBA".to_string(),
+        description: "DIBA".to_string(),
+        precision: 2,
+        supply,
+        seal: issue_seal.to_owned(),
+        iface: iface.to_string(),
+        meta: None,
+    };
+
+    let issue_req = serde_wasm_bindgen::to_value(&issue_req).expect("");
+    let issue_resp: JsValue = resolve(issue_contract(issuer_sk.to_string(), issue_req)).await;
+    let issuer_resp: IssueResponse = json_parse(&issue_resp);
+
+    let mut total_issuer = supply;
+    let mut total_owner = 0;
+    let rounds = vec![TransferRounds::with(20, true)];
+
+    let mut sender = String::new();
+    let mut sender_sk = String::new();
+    let mut sender_desc = String::new();
+    let mut sender_keys = vec![];
+
+    let mut receiver = String::new();
+    let mut receiver_sk = String::new();
+    for (index, round) in rounds.into_iter().enumerate() {
+        if round.is_issuer_sender {
+            sender = "ISSUER".to_string();
+            sender_sk = issuer_sk.to_string();
+            sender_desc = issuer_vault.public.rgb_assets_descriptor_xpub.to_string();
+            sender_keys = vec![
+                SecretString(issuer_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+
+            receiver = "OWNER".to_string();
+            receiver_sk = owner_sk.to_string();
+        } else {
+            sender = "OWNER".to_string();
+            sender_sk = owner_sk.to_string();
+            sender_desc = owner_vault.public.rgb_assets_descriptor_xpub.to_string();
+            sender_keys = vec![
+                SecretString(owner_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+
+            receiver = "ISSUER".to_string();
+            receiver_sk = issuer_sk.to_string();
+        }
+
+        info!(format!(
+            ">>>> ROUND #{index} {sender} SEND {} units to {receiver} <<<<",
+            round.send_amount
+        ));
+        info!(format!("Get Receiver Next UTXO ({receiver})"));
+        let next_utxo: JsValue = resolve(watcher_next_utxo(
+            receiver_sk.clone(),
+            watcher_name.to_string(),
+            iface.to_string(),
+        ))
+        .await;
+        let receiver_next_utxo: NextUtxoResponse = json_parse(&next_utxo);
+        debug!(format!("UTXO ({receiver}): {:?}", receiver_next_utxo.utxo));
+
+        info!(format!("Create Invoice ({receiver})"));
+        let params = HashMap::new();
+        let receiver_utxo = receiver_next_utxo.utxo.unwrap().outpoint.to_string();
+        let receiver_seal = format!("tapret1st:{receiver_utxo}");
+        let invoice_req = InvoiceRequest {
+            contract_id: issuer_resp.contract_id.to_string(),
+            iface: issuer_resp.iface.to_string(),
+            amount: round.send_amount,
+            seal: receiver_seal,
+            params,
+        };
+
+        let invoice_req = serde_wasm_bindgen::to_value(&invoice_req).expect("");
+        let invoice_resp: JsValue =
+            resolve(rgb_create_invoice(receiver_sk.to_string(), invoice_req)).await;
+        let invoice_resp: InvoiceResponse = json_parse(&invoice_resp);
+        debug!(format!(
+            "Invoice ({receiver}): {}",
+            invoice_resp.invoice.to_string()
+        ));
+
+        info!(format!("Create Payment ({sender})"));
+        let full_transfer_req = FullRgbTransferRequest {
+            contract_id: issuer_resp.contract_id.to_string(),
+            iface: issuer_resp.iface.to_string(),
+            rgb_invoice: invoice_resp.invoice.to_string(),
+            descriptor: SecretString(sender_desc.to_string()),
+            change_terminal: "/20/1".to_string(),
+            fee: PsbtFeeRequest::FeeRate(1.1),
             bitcoin_changes: vec![],
         };
 

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -430,7 +430,7 @@ async fn create_transfer_with_fee_rate() {
         "Issuer Show Address {}",
         issuer_next_address.address
     ));
-    let resp = send_coins(&issuer_next_address.address, "0.00010000").await;
+    let resp = send_coins(&issuer_next_address.address, "0.00007000").await;
     debug!(format!("Issuer Receive Bitcoin {:?}", resp));
 
     info!("Create Owner Watcher");

--- a/tests/scripts/send_coins.sh
+++ b/tests/scripts/send_coins.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 docker-compose exec -T node1 cli sendtoaddress $1 $2
-docker-compose exec -T node1 cli -generate 1
+docker-compose exec -T node1 cli -generate 2
 sleep 3

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -65,7 +65,6 @@ async fn create_wallet() -> Result<()> {
         decrypted_wallet.private.btc_descriptor_xprv
     );
     println!("Address (Bitcoin): {}", main_btc_wallet.address);
-    // println!("Address (RGB): {}", main_rgb_wallet.address);
 
     Ok(())
 }


### PR DESCRIPTION
**Description**

This PR intent add fee-rate support to RGB PSBT Creation.

Today `descriptor-wallet` **does not** support it. The workaround used is pre-built psbt and calculate your fee based in tx weight.


Closes #364 