### PR TITLE
Support to RGB Swaps

### DIFF
--- a/.env
+++ b/.env
@@ -22,5 +22,6 @@ BITMASK_ENDPOINT=http://localhost:7070
 CARBONADO_ENDPOINT=http://localhost:7070/carbonado
 BITCOIN_NETWORK=regtest
 STRESS_TEST=false
+UDAS_UTXO=3b367e1facc3174e97658295961faf6a4ed889129c881b7a73db1f074b49bd8a:
 MARKETPLACE_SEED=lion bronze dumb tuna perfect fantasy wall orphan improve business harbor sadness
-UDAS_UTXO=3b367e1facc3174e97658295961faf6a4ed889129c881b7a73db1f074b49bd8a:0
+MARKETPLACE_NOSTR=cd591c134a0d88991326b1619953d0eae2287d315a7c4a93c1e4883a8c26c464

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+# :: Explorers ::
 # BITCOIN_EXPLORER_API_MAINNET=http://18.217.213.66:3000
 # BITCOIN_EXPLORER_API_TESTNET=http://18.217.213.66:3000
 # BITCOIN_EXPLORER_API_SIGNET=http://18.217.213.66:3000
@@ -15,13 +16,23 @@ BITCOIN_EXPLORER_API_REGTEST=http://localhost:3000/regtest/api
 # BITCOIN_ELECTRUM_API_MAINNET=mempool.space:50001
 # BITCOIN_ELECTRUM_API_TESTNET=mempool.space:60001
 # BITCOIN_ELECTRUM_API_SIGNET=mempool.space:60601
+
+# :: LN ::
 LNDHUB_ENDPOINT=https://lndhubx-prod.bitmask.app
 #LNDHUB_ENDPOINT=https://lndhubx.bitmask.app
-# CARBONADO_ENDPOINT=https://qvijq4x0ei.execute-api.us-east-2.amazonaws.com/dev/carbonado
+
+# :: Bitmask & Carbonado Server ::
+STRESS_TEST=false
+BITCOIN_NETWORK=regtest
 BITMASK_ENDPOINT=http://localhost:7070
 CARBONADO_ENDPOINT=http://localhost:7070/carbonado
-BITCOIN_NETWORK=regtest
-STRESS_TEST=false
+# CARBONADO_ENDPOINT=https://qvijq4x0ei.execute-api.us-east-2.amazonaws.com/dev/carbonado
+
+# :: Marketplace ::
 UDAS_UTXO=3b367e1facc3174e97658295961faf6a4ed889129c881b7a73db1f074b49bd8a:
 MARKETPLACE_SEED=lion bronze dumb tuna perfect fantasy wall orphan improve business harbor sadness
 MARKETPLACE_NOSTR=cd591c134a0d88991326b1619953d0eae2287d315a7c4a93c1e4883a8c26c464
+# 1..100
+MARKETPLACE_FEE_PERC=
+# xpub..
+MARKETPLACE_FEE_XPUB=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "bp-core",
  "bp-seals",
  "carbonado",
+ "chrono",
  "commit_verify",
  "console_error_panic_hook",
  "deflate",
@@ -918,18 +919,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2149,7 +2149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -3166,7 +3166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.23",
+ "time",
 ]
 
 [[package]]
@@ -3482,17 +3482,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.26",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -3905,12 +3894,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b650f45ae7dc8558544448253f3e1ae443433637ccd9f9d14d2089ff913480"
+checksum = "b15adb2017ab6437b6704a779ab8bbefe857612f5af9d84b677a1767f965e099"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -668,7 +668,7 @@ dependencies = [
  "getrandom",
  "gloo-console",
  "gloo-net",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "hex",
  "indexmap 1.9.3",
  "inflate",
@@ -679,7 +679,7 @@ dependencies = [
  "nostr-sdk",
  "once_cell",
  "payjoin",
- "postcard 1.0.4",
+ "postcard 1.0.7",
  "pretty_env_logger",
  "psbt",
  "rand",
@@ -1527,11 +1527,11 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gloo-console"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
+checksum = "2a17868f56b4a24f677b17c8cb69958385102fa879418052d60b50bc1727e261"
 dependencies = [
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1540,14 +1540,14 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
+checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "http",
  "js-sys",
  "pin-project",
@@ -1569,19 +1569,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2107,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matchit"
@@ -2491,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa512cd0d087cc9f99ad30a1bf64795b67871edbead083ffc3a4dfafa59aa00"
+checksum = "d534c6e61df1c7166e636ca612d9820d486fe96ddad37f7abc671517b297488e"
 dependencies = [
  "cobs",
  "heapless",
@@ -2633,9 +2620,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -2670,7 +2657,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -2850,13 +2837,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -2881,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -4044,21 +4031,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
  "rustls-webpki 0.100.1",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -4177,11 +4161,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "baid58"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052064cc0caa02b62c88f06a7237304fb297873c78b6e95addecc3c5ddfce4ae"
+checksum = "bc0585242d87ed976e05db6ae86a0f771f140104a4b6c91b4c3e43b9b2357486"
 dependencies = [
  "base58",
  "blake3",
@@ -644,6 +644,7 @@ dependencies = [
  "autosurgeon",
  "axum",
  "axum-macros",
+ "baid58",
  "base64-compat",
  "base85",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ base85 = "2.0.0"
 automerge = "0.5.1"
 autosurgeon = "0.8"
 baid58 = "0.4.4"
+chrono = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.2", features = [
@@ -126,6 +127,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.36"
+
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ blake3 = "1.4.1"
 base85 = "2.0.0"
 automerge = "0.5.1"
 autosurgeon = "0.8"
+baid58 = "0.4.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.2", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,14 +56,14 @@ getrandom = { version = "0.2.10", features = ["js"] }
 hex = "0.4.3"
 indexmap = "1.9.3"
 lightning-invoice = "0.23.0"
-log = "0.4.17"
+log = "0.4.20"
 miniscript_crate = { package = "miniscript", version = "9.0.1", features = [
     "compiler",
 ] }
 nostr-sdk = "0.22.0"
 once_cell = "1.17.1"
 payjoin = { version = "0.8.0", features = ["send"] }
-postcard = { version = "1.0.4", features = ["alloc"] }
+postcard = { version = "1.0.7", features = ["alloc"] }
 pretty_env_logger = "0.5.0"
 psbt = { version = "0.10.0-alpha.2", features = [
     "sign",
@@ -72,7 +72,7 @@ psbt = { version = "0.10.0-alpha.2", features = [
     "construct",
 ] }
 regex = "1.7.0"
-reqwest = { version = "0.11.18", features = ["json"] }
+reqwest = { version = "0.11.20", features = ["json"] }
 rgb-std = { version = "0.10.4" }
 rgb-wallet = { version = "0.10.4" }
 rgb-schemata = { version = "0.10.0-rc.2" }
@@ -91,18 +91,19 @@ automerge = "0.5.1"
 autosurgeon = "0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bdk = { version = "0.28.0", features = [
+bdk = { version = "0.28.2", features = [
     "use-esplora-async",
     "async-interface",
 ], default-features = false }
-gloo-console = "0.2.3"
-gloo-net = { version = "0.3.1", features = ["http"] }
+gloo-console = "0.3.0"
+gloo-net = { version = "0.4.0", features = ["http"] }
 gloo-utils = "0.2.0"
 js-sys = "0.3.63"
 serde-wasm-bindgen = "0.5.0"
 wasm-bindgen = { version = "0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.36"
 web-sys = "0.3.63"
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bdk = { version = "0.28.0", features = [

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -560,7 +560,7 @@ async fn co_metadata(
 async fn co_marketplace_retrieve(Path(name): Path<String>) -> Result<impl IntoResponse, AppError> {
     info!("GET /marketplace/{name}");
 
-    let marketplace_key: String = get_marketplace_nostr_key().await.try_into()?;
+    let marketplace_key: String = get_marketplace_nostr_key().await;
     let filepath = &handle_file(&marketplace_key, &name, 0).await?;
     let fullpath = filepath.to_string_lossy();
     let bytes = fs::read(filepath).await;

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use bitcoin_30::secp256k1::{ecdh::SharedSecret, PublicKey, SecretKey};
 use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
+    bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     carbonado::handle_file,
     constants::{
         get_marketplace_nostr_key, get_marketplace_seed, get_network, get_udas_utxo, switch_network,
@@ -143,7 +143,7 @@ async fn _sign_psbt(
     Json(psbt_req): Json<SignPsbtRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     info!("POST /sign {psbt_req:?}");
-    let psbt_res = sign_psbt_file(psbt_req).await?;
+    let psbt_res = sign_and_publish_psbt_file(psbt_req).await?;
 
     Ok((StatusCode::OK, Json(psbt_res)))
 }

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -499,7 +499,7 @@ async fn co_server_store(
     Path(name): Path<String>,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
-    info!("POST /carbonado/public/{name}, {} bytes", body.len());
+    info!("POST /carbonado/server/{name}, {} bytes", body.len());
     let (filepath, encoded) = server_store(&name, &body, None).await?;
 
     match OpenOptions::new()
@@ -524,7 +524,7 @@ async fn co_server_store(
                 fs::write(&filepath, &body).await?;
             }
             _ => {
-                error!("error in POST /carbonado/public/{name}: {err}");
+                error!("error in POST /carbonado/server/{name}: {err}");
                 return Err(err.into());
             }
         },
@@ -598,7 +598,7 @@ async fn co_metadata(
 }
 
 async fn co_server_retrieve(Path(name): Path<String>) -> Result<impl IntoResponse, AppError> {
-    info!("GET /public/{name}");
+    info!("GET /server/{name}");
 
     let result = server_retrieve(&name).await;
     let cc = CacheControl::new().with_no_cache();
@@ -691,8 +691,8 @@ async fn main() -> Result<()> {
         .route("/transfers/", delete(remove_transfer))
         .route("/key/:pk", get(key))
         .route("/carbonado/status", get(status))
-        .route("/carbonado/public/:name", get(co_server_retrieve))
-        .route("/carbonado/public/:name", post(co_server_store))
+        .route("/carbonado/server/:name", get(co_server_retrieve))
+        .route("/carbonado/server/:name", post(co_server_store))
         .route("/carbonado/:pk/:name", get(co_retrieve))
         .route("/carbonado/:pk/:name", post(co_store))
         .route("/carbonado/:pk/:name/force", post(co_force_store))

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -34,6 +34,7 @@ pub use crate::bitcoin::{
 };
 
 use crate::{
+    bitcoin::keys::get_marketplace_descriptor,
     constants::{DIBA_DESCRIPTOR, DIBA_DESCRIPTOR_VERSION, DIBA_MAGIC_NO, NETWORK},
     debug, info,
     structs::{
@@ -300,6 +301,18 @@ pub async fn get_wallet_data(
         transactions,
         utxos,
     })
+}
+
+pub async fn get_swap_new_address() -> Result<Option<String>, BitcoinError> {
+    info!("get_swap_new_address");
+
+    let markplace_desc = get_marketplace_descriptor().await?;
+    if let Some(markplace_desc) = markplace_desc {
+        let address = get_new_address(&markplace_desc, None).await?;
+        return Ok(Some(address));
+    }
+
+    Ok(None)
 }
 
 pub async fn get_new_address(

--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     bitcoin::{
-        psbt::{sign_original_psbt, sign_psbt, BitcoinPsbtError},
+        psbt::{sign_and_publish_psbt, sign_psbt, BitcoinPsbtError},
         wallet::MemoryWallet,
     },
     debug, info,
@@ -58,7 +58,7 @@ pub async fn create_transaction(
 
     debug!(format!("Create transaction: {details:#?}"));
     debug!("Unsigned PSBT:", base64::encode(&serialize(&psbt)));
-    let details = sign_psbt(wallet, psbt).await?;
+    let details = sign_and_publish_psbt(wallet, psbt).await?;
     info!("PSBT successfully signed");
 
     Ok(details)
@@ -83,7 +83,7 @@ pub async fn create_payjoin(
 
     debug!(format!("Request PayJoin transaction: {details:#?}"));
     debug!("Unsigned Original PSBT:", base64::encode(&serialize(&psbt)));
-    let original_psbt = sign_original_psbt(wallet, psbt.clone()).await?;
+    let original_psbt = sign_psbt(wallet, psbt.clone()).await?;
     info!("Original PSBT successfully signed");
 
     let additional_fee_index = psbt
@@ -146,7 +146,7 @@ pub async fn create_payjoin(
         base64::encode(&serialize(&payjoin_psbt))
     );
     // sign_psbt also broadcasts;
-    let tx = sign_psbt(wallet, payjoin_psbt).await?;
+    let tx = sign_and_publish_psbt(wallet, payjoin_psbt).await?;
 
     Ok(tx)
 }

--- a/src/bitcoin/psbt.rs
+++ b/src/bitcoin/psbt.rs
@@ -20,6 +20,48 @@ pub enum BitcoinPsbtError {
     BdkEsploraError(#[from] bdk::esplora_client::Error),
 }
 
+// Only signs an original psbt.
+pub async fn sign_psbt(
+    wallet: &MemoryWallet,
+    mut psbt: PartiallySignedTransaction,
+) -> Result<PartiallySignedTransaction, BitcoinPsbtError> {
+    debug!("Funding PSBT...");
+    let opts = SignOptions {
+        allow_all_sighashes: true,
+        remove_partial_sigs: false,
+        ..Default::default()
+    };
+    wallet.lock().await.sign(&mut psbt, opts)?;
+    Ok(psbt)
+}
+
+pub async fn multi_sign_psbt(
+    wallets: Vec<MemoryWallet>,
+    mut psbt: PartiallySignedTransaction,
+) -> Result<PartiallySignedTransaction, BitcoinPsbtError> {
+    let total_wallets = wallets.len();
+    debug!(format!(
+        "Signing PSBT ({total_wallets}/{total_wallets}) ..."
+    ));
+
+    let mut sign_count = 0;
+    for wallet in wallets {
+        wallet.lock().await.sign(
+            &mut psbt,
+            SignOptions {
+                allow_all_sighashes: true,
+                remove_partial_sigs: false,
+                ..Default::default()
+            },
+        )?;
+
+        sign_count += 1;
+        debug!(format!("PSBT Sign: ({sign_count}/{total_wallets})"));
+    }
+
+    Ok(psbt)
+}
+
 /// Signs and broadcasts a transaction given a Psbt
 pub async fn sign_and_publish_psbt(
     wallet: &MemoryWallet,
@@ -65,43 +107,7 @@ pub async fn sign_and_publish_psbt(
     }
 }
 
-// Only signs an original psbt.
-pub async fn sign_psbt(
-    wallet: &MemoryWallet,
-    mut psbt: PartiallySignedTransaction,
-) -> Result<PartiallySignedTransaction, BitcoinPsbtError> {
-    debug!("Funding PSBT...");
-    let opts = SignOptions {
-        remove_partial_sigs: false,
-        ..Default::default()
-    };
-    wallet.lock().await.sign(&mut psbt, opts)?;
-    Ok(psbt)
-}
-
-pub async fn multi_sign_psbt(
-    wallets: Vec<MemoryWallet>,
-    mut psbt: PartiallySignedTransaction,
-) -> Result<PartiallySignedTransaction, BitcoinPsbtError> {
-    let total_wallets = wallets.len();
-    debug!(format!(
-        "Signing PSBT ({total_wallets}/{total_wallets}) ..."
-    ));
-
-    let mut sign_count = 0;
-    for wallet in wallets {
-        wallet
-            .lock()
-            .await
-            .sign(&mut psbt, SignOptions::default())?;
-
-        sign_count += 1;
-        debug!(format!("PSBT Sign: ({sign_count}/{total_wallets})"));
-    }
-
-    Ok(psbt)
-}
-
+/// Signs and broadcasts a transaction given a Psbt
 pub async fn multi_sign_and_publish_psbt(
     wallets: Vec<MemoryWallet>,
     mut psbt: PartiallySignedTransaction,
@@ -114,10 +120,14 @@ pub async fn multi_sign_and_publish_psbt(
     let mut sign_count = 0;
     let mut finalized = false;
     for wallet in wallets {
-        finalized = wallet
-            .lock()
-            .await
-            .sign(&mut psbt, SignOptions::default())?;
+        finalized = wallet.lock().await.sign(
+            &mut psbt,
+            SignOptions {
+                allow_all_sighashes: true,
+                remove_partial_sigs: false,
+                ..Default::default()
+            },
+        )?;
 
         sign_count += 1;
         debug!(format!("PSBT Sign: ({sign_count}/{total_wallets})"));

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -6,7 +6,7 @@ use crate::{carbonado::error::CarbonadoError, constants::NETWORK, info, structs:
 pub mod error;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use server::{handle_file, public_retrieve, public_store, retrieve, retrieve_metadata, store};
+pub use server::{handle_file, retrieve, retrieve_metadata, server_retrieve, server_store, store};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod server {
@@ -42,7 +42,7 @@ mod server {
         Ok(())
     }
 
-    pub async fn public_store(
+    pub async fn server_store(
         name: &str,
         input: &[u8],
         metadata: Option<Vec<u8>>,
@@ -105,7 +105,7 @@ mod server {
         Ok((Vec::new(), None))
     }
 
-    pub async fn public_retrieve(name: &str) -> Result<(Vec<u8>, Option<Vec<u8>>), CarbonadoError> {
+    pub async fn server_retrieve(name: &str) -> Result<(Vec<u8>, Option<Vec<u8>>), CarbonadoError> {
         let marketplace_key: String = get_marketplace_nostr_key().await;
 
         let sk = hex::decode(marketplace_key)?;
@@ -195,7 +195,7 @@ mod server {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub use client::{public_retrieve, public_store, retrieve, retrieve_metadata, store};
+pub use client::{retrieve, retrieve_metadata, server_retrieve, server_store, store};
 
 #[cfg(target_arch = "wasm32")]
 mod client {
@@ -275,7 +275,7 @@ mod client {
         }
     }
 
-    pub async fn public_store(
+    pub async fn server_store(
         name: &str,
         input: &[u8],
         _metadata: Option<Vec<u8>>,
@@ -395,7 +395,7 @@ mod client {
         Ok((Vec::new(), None))
     }
 
-    pub async fn public_retrieve(name: &str) -> Result<(Vec<u8>, Option<Vec<u8>>), CarbonadoError> {
+    pub async fn server_retrieve(name: &str) -> Result<(Vec<u8>, Option<Vec<u8>>), CarbonadoError> {
         let network = NETWORK.read().await.to_string();
         let endpoints = CARBONADO_ENDPOINT.read().await.to_string();
         let endpoints: Vec<&str> = endpoints.split(',').collect();

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -287,7 +287,7 @@ mod client {
         let requests = Array::new();
 
         for endpoint in endpoints {
-            let url = format!("{endpoint}/public/{network}-{name}");
+            let url = format!("{endpoint}/server/{network}-{name}");
             let fetch_fn = future_to_promise(fetch_post(url, body.clone()));
             requests.push(&fetch_fn);
         }
@@ -402,7 +402,7 @@ mod client {
 
         let requests = Array::new();
         for endpoint in endpoints.iter() {
-            let url = format!("{endpoint}/public/{network}-{name}");
+            let url = format!("{endpoint}/server/{network}-{name}");
             let fetch_fn = future_to_promise(fetch_get_byte_array(url));
             requests.push(&fetch_fn);
         }

--- a/src/carbonado/error.rs
+++ b/src/carbonado/error.rs
@@ -25,6 +25,8 @@ pub enum CarbonadoError {
     SerdeWasm(#[from] serde_wasm_bindgen::Error),
     /// All endpoints failed error
     AllEndpointsFailed,
+    /// Wrong Nostr private key
+    WrongNostrPrivateKey,
     /// Debug: {0}
     Debug(String),
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -54,12 +54,26 @@ pub static MARKETPLACE_SEED: Lazy<RwLock<String>> =
 pub static MARKETPLACE_NOSTR: Lazy<RwLock<String>> =
     Lazy::new(|| RwLock::new(dot_env("MARKETPLACE_NOSTR")));
 
+pub static MARKETPLACE_FEE_PERC: Lazy<RwLock<String>> =
+    Lazy::new(|| RwLock::new(dot_env("MARKETPLACE_FEE_PERC")));
+
+pub static MARKETPLACE_FEE_XPUB: Lazy<RwLock<String>> =
+    Lazy::new(|| RwLock::new(dot_env("MARKETPLACE_FEE_XPUB")));
+
 pub async fn get_marketplace_seed() -> String {
     MARKETPLACE_SEED.read().await.to_string()
 }
 
 pub async fn get_marketplace_nostr_key() -> String {
     MARKETPLACE_NOSTR.read().await.to_string()
+}
+
+pub async fn get_marketplace_fee_percentage() -> String {
+    MARKETPLACE_FEE_PERC.read().await.to_string()
+}
+
+pub async fn get_marketplace_fee_xpub() -> String {
+    MARKETPLACE_FEE_XPUB.read().await.to_string()
 }
 
 pub static UDAS_UTXO: Lazy<RwLock<String>> = Lazy::new(|| RwLock::new(dot_env("UDAS_UTXO")));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -51,8 +51,15 @@ pub static BITCOIN_ELECTRUM_API: Lazy<RwLock<String>> =
 pub static MARKETPLACE_SEED: Lazy<RwLock<String>> =
     Lazy::new(|| RwLock::new(dot_env("MARKETPLACE_SEED")));
 
+pub static MARKETPLACE_NOSTR: Lazy<RwLock<String>> =
+    Lazy::new(|| RwLock::new(dot_env("MARKETPLACE_NOSTR")));
+
 pub async fn get_marketplace_seed() -> String {
     MARKETPLACE_SEED.read().await.to_string()
+}
+
+pub async fn get_marketplace_nostr_key() -> String {
+    MARKETPLACE_NOSTR.read().await.to_string()
 }
 
 pub static UDAS_UTXO: Lazy<RwLock<String>> = Lazy::new(|| RwLock::new(dot_env("UDAS_UTXO")));
@@ -192,4 +199,8 @@ pub mod storage_keys {
     pub const ASSETS_STOCK: &str = "bitmask-fungible_assets_stock.c15";
     pub const ASSETS_WALLETS: &str = "bitmask-fungible_assets_wallets.c15";
     pub const ASSETS_TRANSFERS: &str = "bitmask_assets_transfers.c15";
+    pub const ASSETS_OFFERS: &str = "bitmask-asset_offers.c15";
+    pub const ASSETS_BIDS: &str = "bitmask-asset_bids.c15";
+    pub const MARKETPLACE_OFFERS: &str = "bitmask-marketplace_public_offers.c15";
+    pub const MARKETPLACE_BIDS: &str = "bitmask-marketplace_public_bids.c15";
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -63,8 +63,8 @@ use crate::{
         IssueMetaRequest, IssueMetadata, IssueRequest, IssueResponse, NewCollectible,
         NextAddressResponse, NextUtxoResponse, NextUtxosResponse, PsbtFeeRequest, PsbtRequest,
         PsbtResponse, ReIssueRequest, ReIssueResponse, RgbBidDetail, RgbBidRequest, RgbBidResponse,
-        RgbBidsReponse, RgbInvoiceResponse, RgbOfferBidsReponse, RgbOfferDetail, RgbOfferRequest,
-        RgbOfferResponse, RgbOffersReponse, RgbPublicOfferDetail, RgbPublicOfferReponse,
+        RgbBidsResponse, RgbInvoiceResponse, RgbOfferBidsResponse, RgbOfferDetail, RgbOfferRequest,
+        RgbOfferResponse, RgbOffersResponse, RgbPublicOfferDetail, RgbPublicOfferResponse,
         RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbSwapRequest, RgbSwapResponse,
         RgbTransferDetail, RgbTransferInternalParams, RgbTransferRequest, RgbTransferResponse,
         RgbTransferStatusResponse, RgbTransfersResponse, SchemaDetail, SchemasResponse,
@@ -1750,7 +1750,7 @@ pub async fn list_transfers(sk: &str, contract_id: String) -> Result<RgbTransfer
     Ok(RgbTransfersResponse { transfers })
 }
 
-pub async fn list_my_orders(sk: &str) -> Result<RgbOfferBidsReponse> {
+pub async fn list_my_orders(sk: &str) -> Result<RgbOfferBidsResponse> {
     let rgb_offers = retrieve_offers(sk).await?;
     let rgb_bids = retrieve_bids(sk).await?;
 
@@ -1766,10 +1766,10 @@ pub async fn list_my_orders(sk: &str) -> Result<RgbOfferBidsReponse> {
         .into_iter()
         .for_each(|(_, bs)| bids.extend(bs.into_iter().map(RgbBidDetail::from)));
 
-    Ok(RgbOfferBidsReponse { offers, bids })
+    Ok(RgbOfferBidsResponse { offers, bids })
 }
 
-pub async fn list_my_offers(sk: &str) -> Result<RgbOffersReponse> {
+pub async fn list_my_offers(sk: &str) -> Result<RgbOffersResponse> {
     let rgb_offers = retrieve_offers(sk).await?;
 
     let mut offers = vec![];
@@ -1778,10 +1778,10 @@ pub async fn list_my_offers(sk: &str) -> Result<RgbOffersReponse> {
         .into_iter()
         .for_each(|(_, offs)| offers.extend(offs.into_iter().map(RgbOfferDetail::from)));
 
-    Ok(RgbOffersReponse { offers })
+    Ok(RgbOffersResponse { offers })
 }
 
-pub async fn list_my_bids(sk: &str) -> Result<RgbBidsReponse> {
+pub async fn list_my_bids(sk: &str) -> Result<RgbBidsResponse> {
     let rgb_bids = retrieve_bids(sk).await?;
     let mut bids = vec![];
     rgb_bids
@@ -1789,10 +1789,10 @@ pub async fn list_my_bids(sk: &str) -> Result<RgbBidsReponse> {
         .into_iter()
         .for_each(|(_, bs)| bids.extend(bs.into_iter().map(RgbBidDetail::from)));
 
-    Ok(RgbBidsReponse { bids })
+    Ok(RgbBidsResponse { bids })
 }
 
-pub async fn list_public_offers(_sk: &str) -> Result<RgbPublicOfferReponse> {
+pub async fn list_public_offers(_sk: &str) -> Result<RgbPublicOfferResponse> {
     let rgb_public_offers = retrieve_public_offers().await?;
 
     let mut offers = vec![];
@@ -1802,7 +1802,7 @@ pub async fn list_public_offers(_sk: &str) -> Result<RgbPublicOfferReponse> {
         .into_iter()
         .for_each(|(_, offs)| offers.extend(offs.into_iter().map(RgbPublicOfferDetail::from)));
 
-    Ok(RgbPublicOfferReponse { offers })
+    Ok(RgbPublicOfferResponse { offers })
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -867,6 +867,8 @@ pub enum RgbSwapError {
     Swap(RgbOfferErrors),
     /// Occurs an error in transfer step. {0}
     Transfer(TransferError),
+    /// Swap fee cannot be decoded. {0}
+    WrongSwapFee(String),
     /// Bitcoin network cannot be decoded. {0}
     WrongNetwork(String),
     /// Bitcoin address cannot be decoded. {0}

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -61,13 +61,12 @@ use crate::{
         ImportRequest, InterfaceDetail, InterfacesResponse, InvoiceRequest, InvoiceResponse,
         IssueMetaRequest, IssueMetadata, IssueRequest, IssueResponse, NewCollectible,
         NextAddressResponse, NextUtxoResponse, NextUtxosResponse, PsbtFeeRequest, PsbtRequest,
-        PsbtResponse, ReIssueRequest, ReIssueResponse, RgbInvoiceResponse,
-        RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbSwapBuyerRequest,
-        RgbSwapBuyerResponse, RgbSwapSellerRequest, RgbSwapSellerResponse, RgbSwapTransferRequest,
-        RgbSwapTransferResponse, RgbTransferDetail, RgbTransferRequest, RgbTransferResponse,
-        RgbTransferStatusResponse, RgbTransfersResponse, SchemaDetail, SchemasResponse,
-        TransferType, TxStatus, UDADetail, UtxoResponse, WatcherDetailResponse, WatcherRequest,
-        WatcherResponse, WatcherUtxoResponse,
+        PsbtResponse, ReIssueRequest, ReIssueResponse, RgbBidRequest, RgbBidResponse,
+        RgbInvoiceResponse, RgbOfferRequest, RgbOfferResponse, RgbRemoveTransferRequest,
+        RgbSaveTransferRequest, RgbSwapRequest, RgbSwapResponse, RgbTransferDetail,
+        RgbTransferRequest, RgbTransferResponse, RgbTransferStatusResponse, RgbTransfersResponse,
+        SchemaDetail, SchemasResponse, TransferType, TxStatus, UDADetail, UtxoResponse,
+        WatcherDetailResponse, WatcherRequest, WatcherResponse, WatcherUtxoResponse,
     },
     validators::RGBContext,
 };
@@ -858,8 +857,8 @@ pub enum RgbSwapError {
 
 pub async fn create_offer_seller(
     sk: &str,
-    request: RgbSwapSellerRequest,
-) -> Result<RgbSwapSellerResponse, RgbSwapError> {
+    request: RgbOfferRequest,
+) -> Result<RgbOfferResponse, RgbSwapError> {
     if let Err(err) = request.validate(&RGBContext::default()) {
         let errors = err
             .flatten()
@@ -894,7 +893,7 @@ pub async fn create_offer_seller(
         .wallets
         .insert(RGB_DEFAULT_NAME.to_owned(), rgb_wallet.clone());
 
-    let RgbSwapSellerRequest {
+    let RgbOfferRequest {
         contract_id,
         contract_amount,
         bitcoin_price,
@@ -943,7 +942,7 @@ pub async fn create_offer_seller(
         seller_psbt.psbt.clone(),
     );
 
-    let resp = RgbSwapSellerResponse {
+    let resp = RgbOfferResponse {
         offer_id: new_offer.clone().offer_id,
         contract_id: contract_id.clone(),
         contract_amount,
@@ -976,8 +975,8 @@ pub async fn create_offer_seller(
 
 pub async fn create_offer_buyer(
     sk: &str,
-    request: RgbSwapBuyerRequest,
-) -> Result<RgbSwapBuyerResponse, RgbSwapError> {
+    request: RgbBidRequest,
+) -> Result<RgbBidResponse, RgbSwapError> {
     if let Err(err) = request.validate(&RGBContext::default()) {
         let errors = err
             .flatten()
@@ -1001,7 +1000,7 @@ pub async fn create_offer_buyer(
         _ => return Err(RgbSwapError::NoWatcher),
     };
 
-    let RgbSwapBuyerRequest {
+    let RgbBidRequest {
         offer_id,
         change_terminal,
         ..
@@ -1097,7 +1096,7 @@ pub async fn create_offer_buyer(
     let invoice = invoice.to_string();
     new_bid.buyer_invoice = invoice.clone();
 
-    let resp = RgbSwapBuyerResponse {
+    let resp = RgbBidResponse {
         bid_id,
         offer_id,
         invoice,
@@ -1120,8 +1119,8 @@ pub async fn create_offer_buyer(
 
 pub async fn create_swap_transfer(
     sk: &str,
-    request: RgbSwapTransferRequest,
-) -> Result<RgbSwapTransferResponse, RgbSwapError> {
+    request: RgbSwapRequest,
+) -> Result<RgbSwapResponse, RgbSwapError> {
     if let Err(err) = request.validate(&RGBContext::default()) {
         let errors = err
             .flatten()
@@ -1140,7 +1139,7 @@ pub async fn create_swap_transfer(
         .await
         .map_err(RgbSwapError::IO)?;
 
-    let RgbSwapTransferRequest {
+    let RgbSwapRequest {
         offer_id,
         bid_id,
         swap_psbt,
@@ -1185,7 +1184,7 @@ pub async fn create_swap_transfer(
         .await
         .map_err(RgbSwapError::IO)?;
 
-    Ok(RgbSwapTransferResponse {
+    Ok(RgbSwapResponse {
         consig_id,
         final_consig,
         final_psbt,

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -62,12 +62,13 @@ use crate::{
         IssueMetaRequest, IssueMetadata, IssueRequest, IssueResponse, NewCollectible,
         NextAddressResponse, NextUtxoResponse, NextUtxosResponse, PsbtFeeRequest, PsbtRequest,
         PsbtResponse, ReIssueRequest, ReIssueResponse, RgbBidDetail, RgbBidRequest, RgbBidResponse,
-        RgbInvoiceResponse, RgbOfferBidsReponse, RgbOfferDetail, RgbOfferRequest, RgbOfferResponse,
-        RgbPublicOfferReponse, RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbSwapRequest,
-        RgbSwapResponse, RgbTransferDetail, RgbTransferInternalParams, RgbTransferRequest,
-        RgbTransferResponse, RgbTransferStatusResponse, RgbTransfersResponse, SchemaDetail,
-        SchemasResponse, TransferType, TxStatus, UDADetail, UtxoResponse, WatcherDetailResponse,
-        WatcherRequest, WatcherResponse, WatcherUtxoResponse,
+        RgbBidsReponse, RgbInvoiceResponse, RgbOfferBidsReponse, RgbOfferDetail, RgbOfferRequest,
+        RgbOfferResponse, RgbOffersReponse, RgbPublicOfferDetail, RgbPublicOfferReponse,
+        RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbSwapRequest, RgbSwapResponse,
+        RgbTransferDetail, RgbTransferInternalParams, RgbTransferRequest, RgbTransferResponse,
+        RgbTransferStatusResponse, RgbTransfersResponse, SchemaDetail, SchemasResponse,
+        TransferType, TxStatus, UDADetail, UtxoResponse, WatcherDetailResponse, WatcherRequest,
+        WatcherResponse, WatcherUtxoResponse,
     },
     validators::RGBContext,
 };
@@ -1749,7 +1750,7 @@ pub async fn list_transfers(sk: &str, contract_id: String) -> Result<RgbTransfer
     Ok(RgbTransfersResponse { transfers })
 }
 
-pub async fn list_offers(sk: &str) -> Result<RgbOfferBidsReponse> {
+pub async fn list_my_orders(sk: &str) -> Result<RgbOfferBidsReponse> {
     let rgb_offers = retrieve_offers(sk).await?;
     let rgb_bids = retrieve_bids(sk).await?;
 
@@ -1768,6 +1769,29 @@ pub async fn list_offers(sk: &str) -> Result<RgbOfferBidsReponse> {
     Ok(RgbOfferBidsReponse { offers, bids })
 }
 
+pub async fn list_my_offers(sk: &str) -> Result<RgbOffersReponse> {
+    let rgb_offers = retrieve_offers(sk).await?;
+
+    let mut offers = vec![];
+    rgb_offers
+        .offers
+        .into_iter()
+        .for_each(|(_, offs)| offers.extend(offs.into_iter().map(RgbOfferDetail::from)));
+
+    Ok(RgbOffersReponse { offers })
+}
+
+pub async fn list_my_bids(sk: &str) -> Result<RgbBidsReponse> {
+    let rgb_bids = retrieve_bids(sk).await?;
+    let mut bids = vec![];
+    rgb_bids
+        .bids
+        .into_iter()
+        .for_each(|(_, bs)| bids.extend(bs.into_iter().map(RgbBidDetail::from)));
+
+    Ok(RgbBidsReponse { bids })
+}
+
 pub async fn list_public_offers(_sk: &str) -> Result<RgbPublicOfferReponse> {
     let rgb_public_offers = retrieve_public_offers().await?;
 
@@ -1776,7 +1800,7 @@ pub async fn list_public_offers(_sk: &str) -> Result<RgbPublicOfferReponse> {
         .rgb_offers
         .offers
         .into_iter()
-        .for_each(|(_, offs)| offers.extend(offs.into_iter().map(RgbOfferDetail::from)));
+        .for_each(|(_, offs)| offers.extend(offs.into_iter().map(RgbPublicOfferDetail::from)));
 
     Ok(RgbPublicOfferReponse { offers })
 }

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -365,10 +365,9 @@ pub async fn retrieve_public_offers(name: &str) -> Result<LocalRgbOffers, Storag
     let main_name = &format!("{hashed_name}.c15");
     let original_name = &format!("{hashed_name}-diff.c15");
 
-    let (data, _) = public_retrieve(main_name, vec![])
+    let (data, _) = public_retrieve(main_name)
         .await
         .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
-
     if data.is_empty() {
         Ok(LocalRgbOffers {
             doc: automerge::AutoCommit::new().save(),
@@ -407,7 +406,7 @@ pub async fn store_public_offers(name: &str, changes: &[u8]) -> Result<(), Stora
     let main_name = &format!("{hashed_name}.c15");
     let original_name = &format!("{hashed_name}-diff.c15");
 
-    let (original_bytes, _) = public_retrieve(original_name, vec![])
+    let (original_bytes, _) = public_retrieve(original_name)
         .await
         .map_err(|op| StorageError::CarbonadoRetrieve(name.to_string(), op.to_string()))?;
 

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -437,10 +437,15 @@ pub async fn store_public_offers(name: &str, changes: &[u8]) -> Result<(), Stora
 pub async fn retrieve_swap_offer_bid(
     sk: &str,
     name: &str,
+    expire_at: Option<i64>,
 ) -> Result<LocalRgbOfferBid, StorageError> {
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+    let mut hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
         .to_hex()
         .to_lowercase();
+
+    if let Some(expire_at) = expire_at {
+        hashed_name = format!("{hashed_name}-{expire_at}");
+    }
 
     let main_name = &format!("{hashed_name}.c15");
     let original_name = &format!("{hashed_name}-diff.c15");
@@ -484,10 +489,15 @@ pub async fn store_swap_offer_bid(
     sk: &str,
     name: &str,
     changes: &[u8],
+    expire_at: Option<i64>,
 ) -> Result<(), StorageError> {
-    let hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
+    let mut hashed_name = blake3::hash(format!("{LIB_ID_RGB}-{name}").as_bytes())
         .to_hex()
         .to_lowercase();
+
+    if let Some(expire_at) = expire_at {
+        hashed_name = format!("{hashed_name}-{expire_at}");
+    }
 
     let main_name = &format!("{hashed_name}.c15");
     let original_name = &format!("{hashed_name}-diff.c15");

--- a/src/rgb/carbonado.rs
+++ b/src/rgb/carbonado.rs
@@ -6,17 +6,16 @@ use rgbstd::{persistence::Stock, stl::LIB_ID_RGB};
 use strict_encoding::{StrictDeserialize, StrictSerialize};
 
 use crate::carbonado::public_store;
-use crate::rgb::crdt::LocalRgbAccount;
-use crate::rgb::crdt::RawRgbAccount;
-use crate::rgb::structs::RgbTransfers;
+use crate::rgb::crdt::{LocalRgbAccount, LocalRgbOffers, RawRgbAccount};
+
+use crate::rgb::{
+    structs::RgbTransfers,
+    swap::{RgbBids, RgbOffers},
+};
 use crate::{
     carbonado::{public_retrieve, retrieve, store},
     rgb::{constants::RGB_STRICT_TYPE_VERSION, structs::RgbAccount},
 };
-
-use super::crdt::LocalRgbOffers;
-use super::swap::RgbBids;
-use super::swap::RgbOffers;
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
 #[display(doc_comments)]

--- a/src/rgb/crdt.rs
+++ b/src/rgb/crdt.rs
@@ -12,6 +12,8 @@ use std::{
 
 use crate::rgb::structs::RgbAccount;
 
+use super::swap::RgbOffers;
+
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
 #[display(doc_comments)]
 pub enum RgbMergeError {
@@ -283,4 +285,11 @@ pub struct LocalRgbAccount {
 pub struct LocalCopyData {
     pub doc: Vec<u8>,
     pub data: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Display)]
+#[display(doc_comments)]
+pub struct LocalRgbOffers {
+    pub doc: Vec<u8>,
+    pub rgb_offers: RgbOffers,
 }

--- a/src/rgb/crdt.rs
+++ b/src/rgb/crdt.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::rgb::structs::RgbAccount;
 
-use super::swap::RgbOffers;
+use super::swap::{PublicRgbOffers, RgbBidSwap};
 
 #[derive(Debug, Clone, Eq, PartialEq, Display, From, Error)]
 #[display(doc_comments)]
@@ -291,5 +291,12 @@ pub struct LocalCopyData {
 #[display(doc_comments)]
 pub struct LocalRgbOffers {
     pub doc: Vec<u8>,
-    pub rgb_offers: RgbOffers,
+    pub rgb_offers: PublicRgbOffers,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Display)]
+#[display(doc_comments)]
+pub struct LocalRgbOfferBid {
+    pub doc: Vec<u8>,
+    pub rgb_bid: RgbBidSwap,
 }

--- a/src/rgb/fs.rs
+++ b/src/rgb/fs.rs
@@ -102,8 +102,9 @@ pub async fn retrieve_public_offers() -> Result<LocalRgbOffers, RgbPersistenceEr
 pub async fn retrieve_swap_offer_bid(
     sk: &str,
     name: &str,
+    expire_at: Option<i64>,
 ) -> Result<LocalRgbOfferBid, RgbPersistenceError> {
-    let stock = retrieve_rgb_swap_offer_bid(sk, name)
+    let stock = retrieve_rgb_swap_offer_bid(sk, name, expire_at)
         .await
         .map_err(|op| RgbPersistenceError::RetrieveSwapBids(op.to_string()))?;
 
@@ -186,8 +187,9 @@ pub async fn store_swap_bids(
     sk: &str,
     name: &str,
     changes: Vec<u8>,
+    expire_at: Option<i64>,
 ) -> Result<(), RgbPersistenceError> {
-    store_swap_offer_bid(sk, name, &changes)
+    store_swap_offer_bid(sk, name, &changes, expire_at)
         .await
         .map_err(|op| RgbPersistenceError::WriteSwapBids(op.to_string()))
 }

--- a/src/rgb/fs.rs
+++ b/src/rgb/fs.rs
@@ -33,6 +33,8 @@ pub enum RgbPersistenceError {
     RetrieveRgbTransfers(String),
     // Retrieve Offers Error. {0}
     RetrieveRgbOffers(String),
+    // Retrieve Public Offers Error. {0}
+    RetrievePublicOffers(String),
     // Retrieve Bids Error. {0}
     RetrieveRgbBids(String),
     // Store Stock Error. {0}
@@ -43,6 +45,8 @@ pub enum RgbPersistenceError {
     WriteRgbAccountFork(String),
     // Store Transfers Error. {0}
     WriteRgbTransfers(String),
+    // Store Offers (Fork) Error. {0}
+    WriteRgbOffersFork(String),
 }
 
 pub async fn retrieve_stock(sk: &str) -> Result<Stock, RgbPersistenceError> {
@@ -80,7 +84,7 @@ pub async fn retrieve_local_account(sk: &str) -> Result<LocalRgbAccount, RgbPers
 pub async fn retrieve_public_offers() -> Result<LocalRgbOffers, RgbPersistenceError> {
     let stock = retrieve_rgb_public_offers(MARKETPLACE_OFFERS)
         .await
-        .map_err(|op| RgbPersistenceError::RetrieveRgbOffers(op.to_string()))?;
+        .map_err(|op| RgbPersistenceError::RetrievePublicOffers(op.to_string()))?;
 
     Ok(stock)
 }
@@ -160,7 +164,7 @@ pub async fn store_bids(sk: &str, rgb_bids: RgbBids) -> Result<(), RgbPersistenc
 pub async fn store_public_offers(changes: Vec<u8>) -> Result<(), RgbPersistenceError> {
     store_rgb_public_offers(MARKETPLACE_OFFERS, &changes)
         .await
-        .map_err(|op| RgbPersistenceError::WriteRgbAccountFork(op.to_string()))
+        .map_err(|op| RgbPersistenceError::WriteRgbOffersFork(op.to_string()))
 }
 
 pub async fn store_stock_account(

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -37,7 +37,7 @@ use crate::rgb::{
     resolvers::ExplorerResolver,
     structs::AddressAmount,
     structs::RgbExtractTransfer,
-    swap::{extract_transfer as extract_swap_transfer, get_public_offer, RgbBid, RgbOffer},
+    swap::{extract_transfer as extract_swap_transfer, get_public_offer, RgbBid, RgbOfferSwap},
     transfer::extract_transfer,
     wallet::sync_wallet,
     wallet::{get_address, next_utxos},
@@ -647,6 +647,7 @@ pub async fn prebuild_seller_swap(
 }
 
 pub async fn prebuild_buyer_swap(
+    sk: &str,
     request: RgbBidRequest,
     rgb_wallet: &mut RgbWallet,
     resolver: &mut ExplorerResolver,
@@ -719,7 +720,7 @@ pub async fn prebuild_buyer_swap(
         }
     }
 
-    let RgbOffer {
+    let RgbOfferSwap {
         seller_address,
         bitcoin_price,
         ..
@@ -837,6 +838,7 @@ pub async fn prebuild_buyer_swap(
 
     let bitcoin_utxos = bitcoin_inputs.clone().into_iter().map(|x| x.utxo).collect();
     let new_bid = RgbBid::new(
+        sk.to_string(),
         offer_id,
         offer.contract_id.clone(),
         asset_amount,

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -17,7 +17,7 @@ use crate::{
     constants::NETWORK,
     structs::{
         AllocationDetail, AllocationValue, AssetType, FullRgbTransferRequest, PsbtFeeRequest,
-        PsbtInputRequest, SecretString,
+        PsbtInputRequest, RgbSwapBuyerRequest, RgbSwapSellerRequest, SecretString,
     },
     validators::RGBContext,
 };
@@ -37,7 +37,11 @@ use crate::rgb::{
     TransferError,
 };
 
-use super::prefetch::prefetch_resolver_txs;
+use super::{
+    prefetch::prefetch_resolver_txs,
+    swap::{get_public_offer, RgbBid},
+    RgbSwapError,
+};
 
 pub const DUST_LIMIT_SATOSHI: u64 = 546;
 
@@ -373,4 +377,437 @@ pub async fn prebuild_transfer_asset(
     }
 
     Ok((assets_inputs, bitcoin_inputs, bitcoin_changes, fee_value))
+}
+
+pub async fn prebuild_seller_swap(
+    request: RgbSwapSellerRequest,
+    stock: &mut Stock,
+    rgb_wallet: &mut RgbWallet,
+    resolver: &mut ExplorerResolver,
+) -> Result<
+    (
+        Vec<AllocationDetail>,
+        Vec<PsbtInputRequest>,
+        Vec<PsbtInputRequest>,
+        Vec<String>,
+        u64,
+    ),
+    RgbSwapError,
+> {
+    if let Err(err) = request.validate(&RGBContext::default()) {
+        let errors = err
+            .flatten()
+            .into_iter()
+            .map(|(f, e)| (f, e.to_string()))
+            .collect();
+        return Err(RgbSwapError::Validation(errors));
+    }
+
+    let contract_id = ContractId::from_str(&request.contract_id).map_err(|_| {
+        let mut errors = BTreeMap::new();
+        errors.insert("contract_id".to_string(), "invalid contract id".to_string());
+        RgbSwapError::Validation(errors)
+    })?;
+
+    let RgbSwapSellerRequest {
+        descriptor,
+        iface: iface_name,
+        contract_amount: target_amount,
+        mut bitcoin_changes,
+        ..
+    } = request;
+
+    let wildcard_terminal = "/*/*";
+    let mut universal_desc = descriptor.to_string();
+    for contract_type in [
+        AssetType::RGB20,
+        AssetType::RGB21,
+        AssetType::Contract,
+        AssetType::Bitcoin,
+        AssetType::Change,
+    ] {
+        let contract_index = contract_type as u32;
+        let terminal_step = format!("/{contract_index}/*");
+        if universal_desc.contains(&terminal_step) {
+            universal_desc = universal_desc.replace(&terminal_step, wildcard_terminal);
+            break;
+        }
+    }
+
+    let universal_desc = SecretString(universal_desc);
+    let mut all_unspents = vec![];
+
+    // Get All Assets UTXOs
+    let contract_index = if let "RGB20" = iface_name.as_str() {
+        AssetType::RGB20
+    } else {
+        AssetType::RGB21
+    };
+
+    let iface = stock
+        .iface_by_name(&tn!(iface_name))
+        .map_err(|_| RgbSwapError::NoContract)?;
+    let contract_iface = stock
+        .contract_iface(contract_id, iface.iface_id())
+        .map_err(|_| RgbSwapError::NoContract)?;
+
+    let contract_index = contract_index as u32;
+    sync_wallet(contract_index, rgb_wallet, resolver);
+    prefetch_resolver_utxos(
+        contract_index,
+        rgb_wallet,
+        resolver,
+        Some(RGB_DEFAULT_FETCH_LIMIT),
+    )
+    .await;
+    prefetch_resolver_allocations(contract_iface, resolver).await;
+
+    let contract = export_contract(contract_id, stock, resolver, &mut Some(rgb_wallet.clone()))
+        .map_err(RgbSwapError::Export)?;
+
+    let allocations: Vec<AllocationDetail> = contract
+        .allocations
+        .into_iter()
+        .filter(|x| x.is_mine && !x.is_spent)
+        .collect();
+
+    let asset_total: u64 = allocations
+        .clone()
+        .into_iter()
+        .filter(|a| a.is_mine && !a.is_spent)
+        .map(|a| match a.value {
+            AllocationValue::Value(value) => value.to_owned(),
+            AllocationValue::UDA(_) => 1,
+        })
+        .sum();
+
+    if asset_total < target_amount {
+        let mut errors = BTreeMap::new();
+        errors.insert("contract".to_string(), "insufficient state".to_string());
+        return Err(RgbSwapError::Validation(errors));
+    }
+
+    let asset_unspent_utxos = &mut next_utxos(contract_index, rgb_wallet.clone(), resolver)
+        .map_err(|_| RgbSwapError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string())))?;
+
+    let mut asset_total = 0;
+    let mut assets_inputs = vec![];
+    let mut assets_allocs = vec![];
+
+    let mut rng = StdRng::from_entropy();
+    let rnd_amount = rng.gen_range(600..1500);
+    let mut total_asset_bitcoin_unspend: u64 = 0;
+    for alloc in allocations.iter() {
+        match alloc.value {
+            AllocationValue::Value(alloc_value) => {
+                if asset_total >= target_amount {
+                    break;
+                }
+
+                let input = PsbtInputRequest {
+                    descriptor: universal_desc.clone(),
+                    utxo: alloc.utxo.clone(),
+                    utxo_terminal: alloc.derivation.to_string(),
+                    tapret: None,
+                };
+                if !assets_inputs
+                    .clone()
+                    .into_iter()
+                    .any(|x: PsbtInputRequest| x.utxo == alloc.utxo)
+                {
+                    assets_inputs.push(input);
+                    assets_allocs.push(alloc.clone());
+                    total_asset_bitcoin_unspend += asset_unspent_utxos
+                        .clone()
+                        .into_iter()
+                        .filter(|x| {
+                            x.outpoint.to_string() == alloc.utxo.clone()
+                                && alloc.is_mine
+                                && !alloc.is_spent
+                        })
+                        .map(|x| x.amount)
+                        .sum::<u64>();
+                    asset_total += alloc_value;
+                }
+            }
+            AllocationValue::UDA(_) => {
+                let input = PsbtInputRequest {
+                    descriptor: universal_desc.clone(),
+                    utxo: alloc.utxo.clone(),
+                    utxo_terminal: alloc.derivation.to_string(),
+                    tapret: None,
+                };
+                if !assets_inputs
+                    .clone()
+                    .into_iter()
+                    .any(|x| x.utxo == alloc.utxo)
+                {
+                    assets_inputs.push(input);
+                    assets_allocs.push(alloc.clone());
+                    total_asset_bitcoin_unspend += asset_unspent_utxos
+                        .clone()
+                        .into_iter()
+                        .filter(|x| {
+                            x.outpoint.to_string() == alloc.utxo.clone()
+                                && alloc.is_mine
+                                && !alloc.is_spent
+                        })
+                        .map(|x| x.amount)
+                        .sum::<u64>();
+                }
+                break;
+            }
+        }
+    }
+
+    // Get All Bitcoin UTXOs
+    let total_bitcoin_spend: u64 = bitcoin_changes
+        .clone()
+        .into_iter()
+        .map(|x| {
+            let recipient = AddressAmount::from_str(&x).expect("invalid address amount format");
+            recipient.amount
+        })
+        .sum();
+    let mut bitcoin_inputs = vec![];
+
+    let bitcoin_indexes = [0, 1];
+    for bitcoin_index in bitcoin_indexes {
+        sync_wallet(bitcoin_index, rgb_wallet, resolver);
+        prefetch_resolver_utxos(
+            bitcoin_index,
+            rgb_wallet,
+            resolver,
+            Some(BITCOIN_DEFAULT_FETCH_LIMIT),
+        )
+        .await;
+        prefetch_resolver_user_utxo_status(bitcoin_index, rgb_wallet, resolver, false).await;
+
+        let mut unspent_utxos =
+            next_utxos(bitcoin_index, rgb_wallet.clone(), resolver).map_err(|_| {
+                RgbSwapError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string()))
+            })?;
+
+        all_unspents.append(&mut unspent_utxos);
+    }
+
+    let mut bitcoin_total = total_asset_bitcoin_unspend;
+    let total_spendable = rnd_amount + total_bitcoin_spend;
+
+    for utxo in all_unspents {
+        if bitcoin_total > total_spendable {
+            break;
+        } else {
+            let TerminalPath { app, index } = utxo.derivation.terminal;
+            let btc_input = PsbtInputRequest {
+                descriptor: universal_desc.clone(),
+                utxo: utxo.outpoint.to_string(),
+                utxo_terminal: format!("/{app}/{index}"),
+                tapret: None,
+            };
+            if !bitcoin_inputs
+                .clone()
+                .into_iter()
+                .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
+            {
+                bitcoin_inputs.push(btc_input);
+                bitcoin_total += utxo.amount;
+            }
+        }
+    }
+
+    let fee_value = 0;
+    let change_value = bitcoin_total - total_spendable;
+    let total_spendable = fee_value + rnd_amount + total_bitcoin_spend;
+    if bitcoin_total < total_spendable {
+        return Err(RgbSwapError::Inflation {
+            input: bitcoin_total,
+            output: total_spendable,
+        });
+    } else if change_value > 0 {
+        let network = NETWORK.read().await.to_string();
+        let network = Network::from_str(&network)
+            .map_err(|err| RgbSwapError::WrongNetwork(err.to_string()))?;
+
+        let network = AddressNetwork::from(network);
+        let change_address = get_address(1, 0, rgb_wallet.clone(), network)
+            .map_err(|err| RgbSwapError::WrongNetwork(err.to_string()))?
+            .address;
+
+        let change_bitcoin = format!("{change_address}:{change_value}");
+        bitcoin_changes.push(change_bitcoin);
+    }
+
+    Ok((
+        assets_allocs,
+        assets_inputs,
+        bitcoin_inputs,
+        bitcoin_changes,
+        fee_value,
+    ))
+}
+
+pub async fn prebuild_buyer_swap(
+    request: RgbSwapBuyerRequest,
+    rgb_wallet: &mut RgbWallet,
+    resolver: &mut ExplorerResolver,
+) -> Result<(RgbBid, Vec<PsbtInputRequest>, Vec<String>, u64), RgbSwapError> {
+    if let Err(err) = request.validate(&RGBContext::default()) {
+        let errors = err
+            .flatten()
+            .into_iter()
+            .map(|(f, e)| (f, e.to_string()))
+            .collect();
+        return Err(RgbSwapError::Validation(errors));
+    }
+
+    let RgbSwapBuyerRequest {
+        descriptor,
+        offer_id,
+        fee,
+        asset_amount,
+        ..
+    } = request;
+
+    let wildcard_terminal = "/*/*";
+    let mut universal_desc = descriptor.to_string();
+    for contract_type in [AssetType::Bitcoin, AssetType::Change] {
+        let contract_index = contract_type as u32;
+        let terminal_step = format!("/{contract_index}/*");
+        if universal_desc.contains(&terminal_step) {
+            universal_desc = universal_desc.replace(&terminal_step, wildcard_terminal);
+            break;
+        }
+    }
+
+    let universal_desc = SecretString(universal_desc);
+    let mut all_unspents = vec![];
+
+    // Retrieve Offer
+    let offer = get_public_offer(offer_id.clone())
+        .await
+        .map_err(RgbSwapError::Buyer)?;
+
+    // Retrieve Bitcoin UTXOs
+    let mut bitcoin_inputs = vec![];
+    let bitcoin_indexes = [AssetType::Bitcoin, AssetType::Change];
+    for bitcoin_index in bitcoin_indexes {
+        let bitcoin_index = bitcoin_index as u32;
+        sync_wallet(bitcoin_index, rgb_wallet, resolver);
+        prefetch_resolver_utxos(
+            bitcoin_index,
+            rgb_wallet,
+            resolver,
+            Some(BITCOIN_DEFAULT_FETCH_LIMIT),
+        )
+        .await;
+        prefetch_resolver_user_utxo_status(bitcoin_index, rgb_wallet, resolver, false).await;
+
+        let mut unspent_utxos =
+            next_utxos(bitcoin_index, rgb_wallet.clone(), resolver).map_err(|_| {
+                RgbSwapError::IO(RgbPersistenceError::RetrieveRgbAccount("".to_string()))
+            })?;
+
+        all_unspents.append(&mut unspent_utxos);
+    }
+
+    let mut bitcoin_total = 0;
+    let total_spendable = offer.bitcoin_price;
+    let bitcoin_changes = vec![format!("{}:{}", offer.seller_address, offer.bitcoin_price)];
+    let (_, fee_value) = match fee.clone() {
+        PsbtFeeRequest::Value(fee_value) => {
+            let total_spendable = fee_value + total_spendable;
+            for utxo in all_unspents {
+                if bitcoin_total > total_spendable {
+                    break;
+                } else {
+                    let TerminalPath { app, index } = utxo.derivation.terminal;
+                    let btc_input = PsbtInputRequest {
+                        descriptor: universal_desc.clone(),
+                        utxo: utxo.outpoint.to_string(),
+                        utxo_terminal: format!("/{app}/{index}"),
+                        tapret: None,
+                    };
+                    if !bitcoin_inputs
+                        .clone()
+                        .into_iter()
+                        .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
+                    {
+                        bitcoin_inputs.push(btc_input);
+                        bitcoin_total += utxo.amount;
+                    }
+                }
+            }
+
+            let change_value = bitcoin_total - total_spendable;
+            (change_value, fee_value)
+        }
+        PsbtFeeRequest::FeeRate(fee_rate) => {
+            // Increase dust limit to avoid dust change
+            let total_spendable = total_spendable + DUST_LIMIT_SATOSHI;
+            for utxo in all_unspents {
+                if total_spendable < bitcoin_total {
+                    break;
+                } else {
+                    let TerminalPath { app, index } = utxo.derivation.terminal;
+                    let btc_input = PsbtInputRequest {
+                        descriptor: universal_desc.clone(),
+                        utxo: utxo.outpoint.to_string(),
+                        utxo_terminal: format!("/{app}/{index}"),
+                        tapret: None,
+                    };
+                    if !bitcoin_inputs
+                        .clone()
+                        .into_iter()
+                        .any(|x: PsbtInputRequest| x.utxo == utxo.outpoint.to_string())
+                    {
+                        bitcoin_inputs.push(btc_input);
+                        bitcoin_total += utxo.amount;
+                    }
+                }
+            }
+
+            let txids = bitcoin_inputs
+                .clone()
+                .into_iter()
+                .map(|x| bitcoin::Txid::from_str(&x.utxo[..64]).expect("wrong txid"))
+                .collect();
+            prefetch_resolver_txs(txids, resolver).await;
+
+            let (change_value, fee) = estimate_fee_tx(
+                vec![],
+                bitcoin_inputs.clone(),
+                bitcoin_changes.clone(),
+                fee_rate,
+                rgb_wallet,
+                Some(0),
+                None,
+                resolver,
+            )
+            .map_err(RgbSwapError::Estimate)?;
+
+            (change_value, fee)
+        }
+    };
+
+    let total_spendable = fee_value + offer.bitcoin_price;
+
+    let fee_value = 0;
+    if bitcoin_total < total_spendable {
+        return Err(RgbSwapError::Inflation {
+            input: bitcoin_total,
+            output: total_spendable,
+        });
+    }
+
+    let bitcoin_utxos = bitcoin_inputs.clone().into_iter().map(|x| x.utxo).collect();
+    let new_bid = RgbBid::new(
+        offer_id,
+        offer.contract_id.clone(),
+        asset_amount,
+        offer.bitcoin_price,
+        bitcoin_utxos,
+    );
+
+    Ok((new_bid, bitcoin_inputs, bitcoin_changes, fee_value))
 }

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -17,7 +17,7 @@ use crate::{
     constants::NETWORK,
     structs::{
         AllocationDetail, AllocationValue, AssetType, FullRgbTransferRequest, PsbtFeeRequest,
-        PsbtInputRequest, RgbSwapBuyerRequest, RgbSwapSellerRequest, SecretString,
+        PsbtInputRequest, RgbBidRequest, RgbOfferRequest, SecretString,
     },
     validators::RGBContext,
 };
@@ -381,7 +381,7 @@ pub async fn prebuild_transfer_asset(
 }
 
 pub async fn prebuild_seller_swap(
-    request: RgbSwapSellerRequest,
+    request: RgbOfferRequest,
     stock: &mut Stock,
     rgb_wallet: &mut RgbWallet,
     resolver: &mut ExplorerResolver,
@@ -409,7 +409,7 @@ pub async fn prebuild_seller_swap(
         RgbSwapError::Validation(errors)
     })?;
 
-    let RgbSwapSellerRequest {
+    let RgbOfferRequest {
         descriptor,
         iface: iface_name,
         contract_amount: target_amount,
@@ -646,7 +646,7 @@ pub async fn prebuild_seller_swap(
 }
 
 pub async fn prebuild_buyer_swap(
-    request: RgbSwapBuyerRequest,
+    request: RgbBidRequest,
     rgb_wallet: &mut RgbWallet,
     resolver: &mut ExplorerResolver,
 ) -> Result<(RgbBid, Vec<PsbtInputRequest>, Vec<String>, u64), RgbSwapError> {
@@ -659,7 +659,7 @@ pub async fn prebuild_buyer_swap(
         return Err(RgbSwapError::Validation(errors));
     }
 
-    let RgbSwapBuyerRequest {
+    let RgbBidRequest {
         descriptor,
         offer_id,
         fee,

--- a/src/rgb/prefetch.rs
+++ b/src/rgb/prefetch.rs
@@ -101,16 +101,14 @@ pub async fn prefetch_resolver_rgb(
     asset_type: Option<AssetType>,
 ) {
     use crate::rgb::import::{contract_from_armored, contract_from_other_formats};
+    use crate::rgb::prebuild::prebuild_extract_transfer;
     use amplify::confinement::U32;
     use rgbstd::contract::Genesis;
 
     let esplora_client: EsploraBlockchain =
         EsploraBlockchain::new(&explorer.explorer_url, 1).with_concurrency(6);
-    let contract = if contract.starts_with("-----BEGIN RGB CONTRACT-----") {
-        contract_from_armored(contract)
-    } else {
-        contract_from_other_formats(contract, asset_type, None)
-    };
+    let contract = prebuild_extract_transfer(contract).expect("invalid transfer");
+    let contract = contract.transfer.unbindle();
 
     for anchor_bundle in contract.bundles {
         let transaction_id = &bitcoin::Txid::from_str(&anchor_bundle.anchor.txid.to_hex())

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -156,7 +156,7 @@ pub fn create_psbt(
             .map_err(CreatePsbtError::WrongTerminal)?;
     }
 
-    let mut psbt = Psbt::construct(
+    let psbt = Psbt::construct(
         global_descriptor,
         &inputs,
         &outputs,
@@ -166,9 +166,14 @@ pub fn create_psbt(
     )
     .map_err(|op| CreatePsbtError::Incomplete(op.to_string()))?;
 
+    Ok((psbt, change_index.to_string()))
+}
+
+pub fn set_tapret_position(psbt: Psbt, pos: u16) -> Result<Psbt, CreatePsbtError> {
     // Define Tapret Proprierties
+    let mut psbt = psbt;
     let proprietary_keys = vec![ProprietaryKeyDescriptor {
-        location: ProprietaryKeyLocation::Output((psbt.outputs.len() - 1) as u16),
+        location: ProprietaryKeyLocation::Output(pos),
         ty: ProprietaryKeyType {
             prefix: RGB_PSBT_TAPRET.to_owned(),
             subtype: 0,
@@ -210,7 +215,7 @@ pub fn create_psbt(
         }
     }
 
-    Ok((psbt, change_index.to_string()))
+    Ok(psbt)
 }
 
 pub fn extract_commit(psbt: Psbt) -> Result<(Outpoint, Vec<u8>), DbcPsbtError> {

--- a/src/rgb/structs.rs
+++ b/src/rgb/structs.rs
@@ -3,11 +3,13 @@ use std::{
     str::FromStr,
 };
 
+use amplify::confinement::{Confined, U32};
 use bitcoin::Address;
 use bitcoin_scripts::address::AddressCompat;
 use bp::Txid;
 use rgb::{RgbWallet, TerminalPath};
 
+use rgbstd::containers::{Bindle, Transfer};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
@@ -61,4 +63,15 @@ pub struct RgbTransfer {
     pub consig: String,
     pub tx: Txid,
     pub is_send: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct RgbExtractTransfer {
+    pub consig_id: String,
+    pub contract_id: String,
+    pub tx_id: Txid,
+    pub transfer: Bindle<Transfer>,
+    pub strict: Confined<Vec<u8>, 1, U32>,
+    pub offer_id: Option<String>,
+    pub bid_id: Option<String>,
 }

--- a/src/rgb/structs.rs
+++ b/src/rgb/structs.rs
@@ -71,7 +71,7 @@ pub struct RgbExtractTransfer {
     pub contract_id: String,
     pub tx_id: Txid,
     pub transfer: Bindle<Transfer>,
-    pub strict: Confined<Vec<u8>, 1, U32>,
+    pub strict: Confined<Vec<u8>, 0, U32>,
     pub offer_id: Option<String>,
     pub bid_id: Option<String>,
 }

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -105,8 +105,8 @@ impl RgbOffer {
         expire_at: Option<i64>,
     ) -> Self {
         let secp = Secp256k1::new();
-        let secret = hex::decode(secret).expect("");
-        let secret_key = SecretKey::from_slice(&secret).expect("");
+        let secret = hex::decode(secret).expect("cannot decode hex sk in new RgbOffer");
+        let secret_key = SecretKey::from_slice(&secret).expect("error parsing sk in new RgbOffer");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 
         let asset_amount = allocations
@@ -238,8 +238,8 @@ impl RgbBid {
         bitcoin_utxos: Vec<String>,
     ) -> Self {
         let secp = Secp256k1::new();
-        let secret = hex::decode(secret).expect("");
-        let secret_key = SecretKey::from_slice(&secret).expect("");
+        let secret = hex::decode(secret).expect("cannot decode hex sk in new RgbBid");
+        let secret_key = SecretKey::from_slice(&secret).expect("error parsing sk in new RgbBid");
         let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 
         let mut allocations = bitcoin_utxos;

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -47,8 +47,10 @@ pub struct RgbOffer {
     pub offer_id: OfferId,
     #[garde(skip)]
     pub offer_status: RgbOrderStatus,
-    #[garde(skip)]
+    #[garde(ascii)]
     pub contract_id: AssetId,
+    #[garde(ascii)]
+    pub iface: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
@@ -61,6 +63,7 @@ pub struct RgbOffer {
 impl RgbOffer {
     pub(crate) fn new(
         contract_id: String,
+        iface: String,
         allocations: Vec<AllocationDetail>,
         seller_address: AddressCompat,
         bitcoin_price: u64,
@@ -87,6 +90,7 @@ impl RgbOffer {
             offer_id: hasher.finalize().to_hex().to_string(),
             offer_status: RgbOrderStatus::Open,
             contract_id,
+            iface,
             asset_amount,
             bitcoin_price,
             seller_psbt: psbt,
@@ -260,12 +264,4 @@ pub async fn publish_bid(new_bid: RgbBid) -> Result<(), RgbOfferErrors> {
         .map_err(RgbOfferErrors::IO)?;
 
     Ok(())
-}
-
-pub fn validate_swap(_offer: RgbOffer, _bid: RgbBid) -> Result<(), RgbOfferErrors> {
-    todo!()
-}
-
-pub fn create_swap(_offer: RgbOffer, _bid: RgbBid) -> Result<RgbSwap, RgbOfferErrors> {
-    todo!()
 }

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -1,0 +1,271 @@
+use autosurgeon::{reconcile, Hydrate, Reconcile};
+use bitcoin_scripts::address::AddressCompat;
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::{structs::AllocationDetail, validators::RGBContext};
+
+use super::{
+    crdt::LocalRgbOffers,
+    fs::{retrieve_public_offers, store_public_offers, RgbPersistenceError},
+};
+
+pub type AssetId = String;
+pub type OfferId = String;
+pub type BidId = String;
+
+#[derive(
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Reconcile,
+    Hydrate,
+    Clone,
+    Debug,
+    Display,
+    Default,
+)]
+pub enum RgbOrderStatus {
+    #[default]
+    #[display(inner)]
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "fill")]
+    Fill,
+}
+
+#[derive(Clone, Serialize, Deserialize, Validate, Reconcile, Hydrate, Debug, Display)]
+#[garde(context(RGBContext))]
+#[display("{offer_id} / {contract_id}:{asset_amount} / {bitcoin_price}")]
+pub struct RgbOffer {
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: OfferId,
+    #[garde(skip)]
+    pub offer_status: RgbOrderStatus,
+    #[garde(skip)]
+    pub contract_id: AssetId,
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub asset_amount: u64,
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub bitcoin_price: u64,
+    #[garde(ascii)]
+    pub seller_psbt: String,
+    #[garde(ascii)]
+    pub seller_address: String,
+}
+impl RgbOffer {
+    pub(crate) fn new(
+        contract_id: String,
+        allocations: Vec<AllocationDetail>,
+        seller_address: AddressCompat,
+        bitcoin_price: u64,
+        psbt: String,
+    ) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        let asset_amount = allocations
+            .clone()
+            .into_iter()
+            .map(|a| match a.value {
+                crate::structs::AllocationValue::Value(amount) => amount,
+                crate::structs::AllocationValue::UDA(_) => 1,
+            })
+            .sum();
+
+        let mut asset_utxos: Vec<String> = allocations.into_iter().map(|a| a.utxo).collect();
+        asset_utxos.sort();
+
+        for asset_utxo in asset_utxos {
+            hasher.update(asset_utxo.as_bytes());
+        }
+
+        RgbOffer {
+            offer_id: hasher.finalize().to_hex().to_string(),
+            offer_status: RgbOrderStatus::Open,
+            contract_id,
+            asset_amount,
+            bitcoin_price,
+            seller_psbt: psbt,
+            seller_address: seller_address.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Validate, Reconcile, Hydrate, Debug, Default, Display)]
+#[garde(context(RGBContext))]
+#[display("{bid_id} / {contract_id}:{asset_amount} / {bitcoin_amount}")]
+pub struct RgbBid {
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub bid_id: BidId,
+    #[garde(skip)]
+    pub bid_status: RgbOrderStatus,
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: OfferId,
+    #[garde(skip)]
+    pub contract_id: AssetId,
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub asset_amount: u64,
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub bitcoin_amount: u64,
+    #[garde(ascii)]
+    pub buyer_psbt: String,
+    #[garde(ascii)]
+    pub buyer_outpoint: String,
+}
+
+impl RgbBid {
+    pub(crate) fn new(
+        offer_id: OfferId,
+        contract_id: AssetId,
+        asset_amount: u64,
+        bitcoin_price: u64,
+        bitcoin_utxos: Vec<String>,
+    ) -> Self {
+        let mut hasher = blake3::Hasher::new();
+
+        let mut allocations = bitcoin_utxos;
+        allocations.sort();
+
+        for allocation in allocations {
+            hasher.update(allocation.as_bytes());
+        }
+
+        RgbBid {
+            bid_id: hasher.finalize().to_string(),
+            bid_status: RgbOrderStatus::Open,
+            offer_id,
+            contract_id,
+            asset_amount,
+            bitcoin_amount: bitcoin_price,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Validate, Debug, Display)]
+#[garde(context(RGBContext))]
+#[display("{bid_id} / {offer_id}")]
+pub struct RgbSwap {
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: OfferId,
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub bid_id: BidId,
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub fee: u64,
+    #[garde(ascii)]
+    pub swap_psbt: String,
+    #[garde(ascii)]
+    pub consignment: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Reconcile, Hydrate, Default, Debug)]
+pub struct RgbOffers {
+    pub offers: BTreeMap<AssetId, Vec<RgbOffer>>,
+    pub bids: BTreeMap<OfferId, Vec<BidId>>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Reconcile, Hydrate, Default, Debug)]
+pub struct RgbBids {
+    pub bids: BTreeMap<AssetId, Vec<RgbBid>>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Display, From, Error)]
+#[display(doc_comments)]
+pub enum RgbOfferErrors {
+    IO(RgbPersistenceError),
+    NoOffer(String),
+    AutoMerge(String),
+}
+
+pub async fn get_public_offer(offer_id: OfferId) -> Result<RgbOffer, RgbOfferErrors> {
+    let LocalRgbOffers { doc: _, rgb_offers } =
+        retrieve_public_offers().await.map_err(RgbOfferErrors::IO)?;
+
+    let mut public_offers = vec![];
+    for offers in rgb_offers.offers.values() {
+        public_offers.extend(offers);
+    }
+
+    let offer = match public_offers.into_iter().find(|x| x.offer_id == offer_id) {
+        Some(offer) => offer.clone(),
+        _ => return Err(RgbOfferErrors::NoOffer(offer_id)),
+    };
+
+    Ok(offer)
+}
+
+pub async fn publish_offer(new_offer: RgbOffer) -> Result<(), RgbOfferErrors> {
+    let LocalRgbOffers {
+        doc,
+        mut rgb_offers,
+    } = retrieve_public_offers().await.map_err(RgbOfferErrors::IO)?;
+
+    let mut local_copy = automerge::AutoCommit::load(&doc)
+        .map_err(|op| RgbOfferErrors::AutoMerge(op.to_string()))?;
+    if let Some(offers) = rgb_offers.offers.get(&new_offer.contract_id) {
+        let mut avaliable_offers = offers.to_owned();
+        avaliable_offers.push(new_offer.clone());
+        rgb_offers
+            .offers
+            .insert(new_offer.clone().contract_id, avaliable_offers);
+    } else {
+        rgb_offers
+            .offers
+            .insert(new_offer.clone().contract_id, vec![new_offer]);
+    }
+
+    // TODO: Add change verification (accept only addition operation)
+    reconcile(&mut local_copy, rgb_offers)
+        .map_err(|op| RgbOfferErrors::AutoMerge(op.to_string()))?;
+    store_public_offers(local_copy.save())
+        .await
+        .map_err(RgbOfferErrors::IO)?;
+
+    Ok(())
+}
+
+pub async fn publish_bid(new_bid: RgbBid) -> Result<(), RgbOfferErrors> {
+    let _ = get_public_offer(new_bid.clone().offer_id).await?;
+    let LocalRgbOffers {
+        doc,
+        mut rgb_offers,
+    } = retrieve_public_offers().await.map_err(RgbOfferErrors::IO)?;
+
+    let mut local_copy = automerge::AutoCommit::load(&doc)
+        .map_err(|op| RgbOfferErrors::AutoMerge(op.to_string()))?;
+
+    if let Some(bids) = rgb_offers.bids.get(&new_bid.offer_id) {
+        let mut avaliable_bids = bids.to_owned();
+        avaliable_bids.push(new_bid.bid_id);
+        rgb_offers.bids.insert(new_bid.offer_id, avaliable_bids);
+    } else {
+        rgb_offers
+            .bids
+            .insert(new_bid.offer_id, vec![new_bid.bid_id]);
+    }
+
+    // TODO: Add change verification (accept only addition operation)
+    reconcile(&mut local_copy, rgb_offers)
+        .map_err(|op| RgbOfferErrors::AutoMerge(op.to_string()))?;
+    store_public_offers(local_copy.save())
+        .await
+        .map_err(RgbOfferErrors::IO)?;
+
+    Ok(())
+}
+
+pub fn validate_swap(_offer: RgbOffer, _bid: RgbBid) -> Result<(), RgbOfferErrors> {
+    todo!()
+}
+
+pub fn create_swap(_offer: RgbOffer, _bid: RgbBid) -> Result<RgbSwap, RgbOfferErrors> {
+    todo!()
+}

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -113,6 +113,7 @@ impl RgbOffer {
 
         let id = Array::from_array(hasher.finalize().into());
         let order_id = OrderId(id);
+        let order_id = format!("{order_id:.0}");
 
         RgbOffer {
             offer_id: order_id.to_string(),
@@ -173,6 +174,7 @@ impl RgbBid {
 
         let id = Array::from_array(hasher.finalize().into());
         let order_id = OrderId(id);
+        let order_id = format!("{order_id:.0}");
 
         RgbBid {
             bid_id: order_id.to_string(),
@@ -200,9 +202,13 @@ pub struct RgbBids {
 #[derive(Clone, Eq, PartialEq, Debug, Display, From, Error)]
 #[display(doc_comments)]
 pub enum RgbOfferErrors {
+    /// Occurs an error in retrieve offers. {0}
     IO(RgbPersistenceError),
+    /// Offer #{0} is not found in public orderbook.
     NoOffer(String),
+    /// Bid #{0} is not found in public orderbook.
     NoBid(String),
+    /// Occurs an error in merge step. {0}
     AutoMerge(String),
 }
 
@@ -549,7 +555,7 @@ pub struct OrderId(
 );
 
 impl ToBaid58<32> for OrderId {
-    const HRI: &'static str = "so";
+    const HRI: &'static str = "swap";
     fn to_baid58_payload(&self) -> [u8; 32] {
         self.to_raw_array()
     }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1047,7 +1047,7 @@ pub struct UtxoSpentStatus {
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
 #[display("")]
-pub struct RgbSwapSellerRequest {
+pub struct RgbOfferRequest {
     /// The Contract ID
     #[garde(ascii)]
     #[garde(length(min = 0, max = 100))]
@@ -1076,7 +1076,7 @@ pub struct RgbSwapSellerRequest {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[serde(rename_all = "camelCase")]
 #[display("")]
-pub struct RgbSwapSellerResponse {
+pub struct RgbOfferResponse {
     /// The Contract ID
     pub offer_id: String,
     /// The Contract ID
@@ -1095,7 +1095,7 @@ pub struct RgbSwapSellerResponse {
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
 #[display("")]
-pub struct RgbSwapBuyerRequest {
+pub struct RgbBidRequest {
     /// The Offer ID
     #[garde(ascii)]
     #[garde(length(min = 0, max = 100))]
@@ -1120,7 +1120,7 @@ pub struct RgbSwapBuyerRequest {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[serde(rename_all = "camelCase")]
 #[display("")]
-pub struct RgbSwapBuyerResponse {
+pub struct RgbBidResponse {
     /// The Bid ID
     pub bid_id: String,
     /// The Offer ID
@@ -1137,7 +1137,7 @@ pub struct RgbSwapBuyerResponse {
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
 #[display("")]
-pub struct RgbSwapTransferRequest {
+pub struct RgbSwapRequest {
     /// Offer ID
     #[garde(ascii)]
     #[garde(length(min = 0, max = 100))]
@@ -1153,7 +1153,7 @@ pub struct RgbSwapTransferRequest {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[display("")]
-pub struct RgbSwapTransferResponse {
+pub struct RgbSwapResponse {
     /// Transfer ID
     pub consig_id: String,
     /// Final Consig

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1177,7 +1177,7 @@ pub struct RgbSwapResponse {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[serde(rename_all = "camelCase")]
 #[display("{offers:?}")]
-pub struct RgbPublicOfferReponse {
+pub struct RgbPublicOfferResponse {
     /// Offers
     pub offers: Vec<RgbPublicOfferDetail>,
 }
@@ -1209,7 +1209,7 @@ impl From<RgbOffer> for RgbPublicOfferDetail {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct RgbOfferBidsReponse {
+pub struct RgbOfferBidsResponse {
     /// Offers
     pub offers: Vec<RgbOfferDetail>,
     /// bids
@@ -1218,14 +1218,14 @@ pub struct RgbOfferBidsReponse {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct RgbOffersReponse {
+pub struct RgbOffersResponse {
     /// Offers
     pub offers: Vec<RgbOfferDetail>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct RgbBidsReponse {
+pub struct RgbBidsResponse {
     /// Bids
     pub bids: Vec<RgbBidDetail>,
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -9,9 +9,12 @@ pub use bdk::{Balance, BlockTime, TransactionDetails};
 pub use bitcoin::{util::address::Address, Txid};
 use rgbstd::interface::rgb21::Allocation as AllocationUDA;
 
-use crate::validators::{
-    verify_descriptor, verify_media_types, verify_rgb_invoice, verify_tapret_seal,
-    verify_terminal_path, RGBContext,
+use crate::{
+    rgb::swap::{RgbBid, RgbOffer},
+    validators::{
+        verify_descriptor, verify_media_types, verify_rgb_invoice, verify_tapret_seal,
+        verify_terminal_path, RGBContext,
+    },
 };
 
 #[derive(Serialize, Deserialize)]
@@ -581,6 +584,13 @@ pub struct PublishedPsbtResponse {
     pub txid: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RgbTransferInternalParams {
+    pub offer_id: Option<String>,
+    pub bid_id: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[derive(Validate)]
@@ -1032,6 +1042,7 @@ pub struct BatchRgbTransferItem {
     pub iface: String,
     pub status: TxStatus,
     pub is_accept: bool,
+    pub is_mine: bool,
 }
 
 #[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug, Display)]
@@ -1160,4 +1171,66 @@ pub struct RgbSwapResponse {
     pub final_consig: String,
     /// Final PSBT
     pub final_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[display("")]
+pub struct RgbPublicOfferReponse {
+    /// Offers
+    pub offers: Vec<RgbOfferDetail>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[display("")]
+pub struct RgbOfferBidsReponse {
+    /// Offers
+    pub offers: Vec<RgbOfferDetail>,
+    /// bids
+    pub bids: Vec<RgbBidDetail>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[display("")]
+pub struct RgbOfferDetail {
+    contract_id: String,
+    offer_id: String,
+    status: String,
+    asset_amount: u64,
+    bitcoin_price: u64,
+}
+
+impl From<RgbOffer> for RgbOfferDetail {
+    fn from(value: RgbOffer) -> Self {
+        Self {
+            contract_id: value.contract_id,
+            offer_id: value.offer_id,
+            status: value.offer_status.to_string(),
+            asset_amount: value.asset_amount,
+            bitcoin_price: value.bitcoin_price,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[display("")]
+pub struct RgbBidDetail {
+    contract_id: String,
+    bid_id: String,
+    offer_id: String,
+    status: String,
+    asset_amount: u64,
+    bitcoin_price: u64,
+}
+
+impl From<RgbBid> for RgbBidDetail {
+    fn from(value: RgbBid) -> Self {
+        Self {
+            contract_id: value.contract_id,
+            offer_id: value.offer_id,
+            status: value.bid_status.to_string(),
+            asset_amount: value.asset_amount,
+            bitcoin_price: value.bitcoin_amount,
+            bid_id: value.bid_id,
+        }
+    }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1033,3 +1033,89 @@ pub struct UtxoSpentStatus {
     pub block_height: TxStatus,
     pub spent_height: TxStatus,
 }
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
+#[garde(context(RGBContext))]
+#[serde(rename_all = "camelCase")]
+#[display("")]
+pub struct RgbSwapSellerRequest {
+    /// The Contract ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub contract_id: String,
+    /// The Contract Interface
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 32))]
+    pub iface: String,
+    /// Contract Amount
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub contract_amount: u64,
+    /// Bitcoin Price (in sats)
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub bitcoin_price: u64,
+    /// Universal Descriptor
+    #[garde(custom(verify_descriptor))]
+    pub descriptor: SecretString,
+    /// Asset Terminal Change
+    #[garde(ascii)]
+    pub change_terminal: String,
+    /// Bitcoin Change Addresses (format: {address}:{amount})
+    #[garde(length(min = 0, max = 999))]
+    pub bitcoin_changes: Vec<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[serde(rename_all = "camelCase")]
+#[display("")]
+pub struct RgbSwapSellerResponse {
+    /// The Contract ID
+    pub offer_id: String,
+    /// The Contract ID
+    pub contract_id: String,
+    /// Contract Amount
+    pub contract_amount: u64,
+    /// Bitcoin Price
+    pub bitcoin_price: u64,
+    /// Seller Address
+    pub seller_address: String,
+    /// Seller PSBT (encoded in base64)
+    pub seller_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
+#[garde(context(RGBContext))]
+#[serde(rename_all = "camelCase")]
+#[display("")]
+pub struct RgbSwapBuyerRequest {
+    /// The Offer ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: String,
+    /// Asset Amount
+    #[garde(range(min = u64::MIN, max = u64::MAX))]
+    pub asset_amount: u64,
+    /// Universal Descriptor
+    #[garde(custom(verify_descriptor))]
+    pub descriptor: SecretString,
+    /// Bitcoin Terminal Change
+    #[garde(ascii)]
+    pub change_terminal: String,
+    /// Bitcoin Fee
+    #[garde(dive)]
+    pub fee: PsbtFeeRequest,
+    /// PSBT Seller Side (base64)
+    #[garde(ascii)]
+    pub seller_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[serde(rename_all = "camelCase")]
+#[display("")]
+pub struct RgbSwapBuyerResponse {
+    /// The Offer ID
+    pub offer_id: String,
+    /// Final PSBT (encoded in base64)
+    pub final_psbt: String,
+    /// Fee Value
+    pub fee_value: u64,
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1057,7 +1057,7 @@ pub struct UtxoSpentStatus {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
-#[display("")]
+#[display("{contract_id}:{contract_amount} ** {change_terminal}")]
 pub struct RgbOfferRequest {
     /// The Contract ID
     #[garde(ascii)]
@@ -1086,7 +1086,7 @@ pub struct RgbOfferRequest {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[serde(rename_all = "camelCase")]
-#[display("")]
+#[display("{offer_id}:{contract_amount} = {bitcoin_price}")]
 pub struct RgbOfferResponse {
     /// The Contract ID
     pub offer_id: String,
@@ -1105,7 +1105,7 @@ pub struct RgbOfferResponse {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
-#[display("")]
+#[display("{offer_id}:{asset_amount} ** {change_terminal}")]
 pub struct RgbBidRequest {
     /// The Offer ID
     #[garde(ascii)]
@@ -1130,7 +1130,7 @@ pub struct RgbBidRequest {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
 #[serde(rename_all = "camelCase")]
-#[display("")]
+#[display("{bid_id} ~ {offer_id}")]
 pub struct RgbBidResponse {
     /// The Bid ID
     pub bid_id: String,
@@ -1147,7 +1147,7 @@ pub struct RgbBidResponse {
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
 #[garde(context(RGBContext))]
 #[serde(rename_all = "camelCase")]
-#[display("")]
+#[display("{offer_id} ~ {bid_id}")]
 pub struct RgbSwapRequest {
     /// Offer ID
     #[garde(ascii)]
@@ -1163,7 +1163,8 @@ pub struct RgbSwapRequest {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
-#[display("")]
+#[serde(rename_all = "camelCase")]
+#[display("{consig_id}")]
 pub struct RgbSwapResponse {
     /// Transfer ID
     pub consig_id: String,
@@ -1174,14 +1175,40 @@ pub struct RgbSwapResponse {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
-#[display("")]
+#[serde(rename_all = "camelCase")]
+#[display("{offers:?}")]
 pub struct RgbPublicOfferReponse {
     /// Offers
-    pub offers: Vec<RgbOfferDetail>,
+    pub offers: Vec<RgbPublicOfferDetail>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
-#[display("")]
+#[serde(rename_all = "camelCase")]
+#[display("{offer_id} ~ {contract_id}:{asset_amount} = {bitcoin_price}")]
+pub struct RgbPublicOfferDetail {
+    /// Offer ID
+    offer_id: String,
+    /// Contract ID
+    contract_id: String,
+    /// Asset/Contract Amount
+    asset_amount: u64,
+    /// Bitcoin Price
+    bitcoin_price: u64,
+}
+
+impl From<RgbOffer> for RgbPublicOfferDetail {
+    fn from(value: RgbOffer) -> Self {
+        Self {
+            contract_id: value.contract_id,
+            offer_id: value.offer_id,
+            asset_amount: value.asset_amount,
+            bitcoin_price: value.bitcoin_price,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct RgbOfferBidsReponse {
     /// Offers
     pub offers: Vec<RgbOfferDetail>,
@@ -1189,8 +1216,23 @@ pub struct RgbOfferBidsReponse {
     pub bids: Vec<RgbBidDetail>,
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RgbOffersReponse {
+    /// Offers
+    pub offers: Vec<RgbOfferDetail>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RgbBidsReponse {
+    /// Bids
+    pub bids: Vec<RgbBidDetail>,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
-#[display("")]
+#[serde(rename_all = "camelCase")]
+#[display("{offer_id} ~ {contract_id}:{asset_amount} = {bitcoin_price}")]
 pub struct RgbOfferDetail {
     contract_id: String,
     offer_id: String,
@@ -1212,7 +1254,8 @@ impl From<RgbOffer> for RgbOfferDetail {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
-#[display("")]
+#[serde(rename_all = "camelCase")]
+#[display("{bid_id} ~ {contract_id}:{asset_amount} = {bitcoin_price}")]
 pub struct RgbBidDetail {
     contract_id: String,
     bid_id: String,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1112,8 +1112,14 @@ pub struct RgbSwapBuyerRequest {
 #[serde(rename_all = "camelCase")]
 #[display("")]
 pub struct RgbSwapBuyerResponse {
+    /// The Bid ID
+    pub bid_id: String,
     /// The Offer ID
     pub offer_id: String,
+    /// The Consig ID
+    pub consig_id: String,
+    /// Final Consig (encoded in base64)
+    pub final_consig: String,
     /// Final PSBT (encoded in base64)
     pub final_psbt: String,
     /// Fee Value

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1305,7 +1305,7 @@ pub struct RgbBidDetail {
     bid_id: String,
     /// Offer ID
     offer_id: String,
-    /// Offer Status
+    /// Bid Status
     bid_status: String,
     /// Asset/Contract Amount
     asset_amount: u64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -313,7 +313,7 @@ pub struct ReIssueResponse {
     pub contracts: Vec<IssueResponse>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum AssetType {
     #[serde(rename = "bitcoin")]
@@ -565,7 +565,16 @@ pub struct SignPsbtRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct SignPsbtResponse {
+pub struct SignedPsbtResponse {
+    /// PSBT is signed?
+    pub sign: bool,
+    /// PSBT signed
+    pub psbt: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishedPsbtResponse {
     /// PSBT is signed?
     pub sign: bool,
     /// Transaction id
@@ -1116,12 +1125,39 @@ pub struct RgbSwapBuyerResponse {
     pub bid_id: String,
     /// The Offer ID
     pub offer_id: String,
-    /// The Consig ID
-    pub consig_id: String,
-    /// Final Consig (encoded in base64)
-    pub final_consig: String,
+    /// Buyer Invoice
+    pub invoice: String,
     /// Final PSBT (encoded in base64)
-    pub final_psbt: String,
+    pub swap_psbt: String,
     /// Fee Value
     pub fee_value: u64,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
+#[garde(context(RGBContext))]
+#[serde(rename_all = "camelCase")]
+#[display("")]
+pub struct RgbSwapTransferRequest {
+    /// Offer ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: String,
+    /// Bid ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub bid_id: String,
+    /// Swap PSBT
+    #[garde(ascii)]
+    pub swap_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[display("")]
+pub struct RgbSwapTransferResponse {
+    /// Transfer ID
+    pub consig_id: String,
+    /// Final Consig
+    pub final_consig: String,
+    /// Final PSBT
+    pub final_psbt: String,
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1082,6 +1082,8 @@ pub struct RgbOfferRequest {
     /// Bitcoin Change Addresses (format: {address}:{amount})
     #[garde(length(min = 0, max = 999))]
     pub bitcoin_changes: Vec<String>,
+    #[garde(skip)]
+    pub expire_at: Option<i64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]

--- a/src/validators.rs
+++ b/src/validators.rs
@@ -13,7 +13,7 @@ use crate::structs::{IssueMetaRequest, IssueMetadata, SecretString};
 #[display(inner)]
 pub enum RGBParamsError {
     /// wrong or unspecified seal closed method. Only TapRet (tapret1st)
-    /// is
+    /// is supported
     #[display(doc_comments)]
     NoClosedMethod,
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -444,7 +444,7 @@ pub mod rgb {
 
         future_to_promise(async move {
             let psbt_req: SignPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
-            match crate::bitcoin::sign_psbt_file(psbt_req).await {
+            match crate::bitcoin::sign_and_publish_psbt_file(psbt_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,7 +1,8 @@
 use crate::structs::{
     AcceptRequest, FullRgbTransferRequest, ImportRequest, InvoiceRequest, IssueRequest,
-    PsbtRequest, ReIssueRequest, RgbRemoveTransferRequest, RgbSaveTransferRequest,
-    RgbTransferRequest, SecretString, SignPsbtRequest, WatcherRequest,
+    PsbtRequest, ReIssueRequest, RgbBidRequest, RgbOfferRequest, RgbRemoveTransferRequest,
+    RgbSaveTransferRequest, RgbSwapRequest, RgbTransferRequest, SecretString, SignPsbtRequest,
+    WatcherRequest,
 };
 // use crate::{carbonado, lightning, rgb};
 
@@ -745,6 +746,107 @@ pub mod rgb {
 
         future_to_promise(async move {
             match crate::rgb::decode_invoice(invoice).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn create_offer(nostr_hex_sk: String, request: JsValue) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            let offer_req: RgbOfferRequest = serde_wasm_bindgen::from_value(request).unwrap();
+            match crate::rgb::create_offer_seller(&nostr_hex_sk, offer_req).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn create_bid(nostr_hex_sk: String, request: JsValue) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            let bid_req: RgbBidRequest = serde_wasm_bindgen::from_value(request).unwrap();
+            match crate::rgb::create_offer_buyer(&nostr_hex_sk, bid_req).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn create_swap(nostr_hex_sk: String, request: JsValue) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            let swap_req: RgbSwapRequest = serde_wasm_bindgen::from_value(request).unwrap();
+            match crate::rgb::create_swap_transfer(&nostr_hex_sk, swap_req).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn public_offers(nostr_hex_sk: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::rgb::list_public_offers(&nostr_hex_sk).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn my_orders(nostr_hex_sk: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::rgb::list_my_orders(&nostr_hex_sk).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn my_offers(nostr_hex_sk: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::rgb::list_my_offers(&nostr_hex_sk).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn my_bids(nostr_hex_sk: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::rgb::list_my_bids(&nostr_hex_sk).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/src/web.rs
+++ b/src/web.rs
@@ -445,6 +445,21 @@ pub mod rgb {
 
         future_to_promise(async move {
             let psbt_req: SignPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
+            match crate::bitcoin::sign_psbt_file(psbt_req).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn psbt_sign_and_publish_file(_nostr_hex_sk: String, request: JsValue) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            let psbt_req: SignPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
             match crate::bitcoin::sign_and_publish_psbt_file(psbt_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),

--- a/src/web.rs
+++ b/src/web.rs
@@ -775,7 +775,7 @@ pub mod rgb {
 
         future_to_promise(async move {
             let offer_req: RgbOfferRequest = serde_wasm_bindgen::from_value(request).unwrap();
-            match crate::rgb::create_offer_seller(&nostr_hex_sk, offer_req).await {
+            match crate::rgb::create_seller_offer(&nostr_hex_sk, offer_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),
@@ -790,7 +790,7 @@ pub mod rgb {
 
         future_to_promise(async move {
             let bid_req: RgbBidRequest = serde_wasm_bindgen::from_value(request).unwrap();
-            match crate::rgb::create_offer_buyer(&nostr_hex_sk, bid_req).await {
+            match crate::rgb::create_buyer_bid(&nostr_hex_sk, bid_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -21,6 +21,7 @@ mod rgb {
         mod import;
         mod issue;
         mod states;
+        mod swaps;
         mod transfers;
         mod udas;
         pub mod utils;

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -33,6 +33,7 @@ mod rgb {
         mod imports;
         mod stl_ids;
         mod stl_load;
+        mod swaps;
         mod transfers;
         mod utils;
     }

--- a/tests/rgb/integration/accept.rs
+++ b/tests/rgb/integration/accept.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 use anyhow::Result;
 use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
+    bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     rgb::{
         create_watcher, list_transfers, remove_transfer, save_transfer, verify_transfers,
         watcher_next_address,
@@ -97,7 +97,7 @@ pub async fn allow_save_read_remove_transfers() -> Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 5. Save Consig (Owner Side)
@@ -258,7 +258,7 @@ pub async fn allow_save_and_accept_all_transfers() -> Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 5. Save Consig (Owner Side)

--- a/tests/rgb/integration/collectibles.rs
+++ b/tests/rgb/integration/collectibles.rs
@@ -4,7 +4,7 @@
 //     ISSUER_MNEMONIC,
 // };
 // use bitmask_core::{
-//     bitcoin::{save_mnemonic, sign_psbt_file},
+//     bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
 //     rgb::accept_transfer,
 //     structs::{AcceptRequest, SecretString, SignPsbtRequest},
 // };
@@ -27,7 +27,7 @@
 //         psbt: transfer_resp.psbt,
 //         descriptor: SecretString(issuer_keys.private.rgb_udas_descriptor_xprv),
 //     };
-//     let resp = sign_psbt_file(request).await;
+//     let resp = sign_and_publish_psbt_file(request).await;
 //     assert!(resp.is_ok());
 
 //     let request = AcceptRequest {

--- a/tests/rgb/integration/dustless.rs
+++ b/tests/rgb/integration/dustless.rs
@@ -5,7 +5,10 @@ use crate::rgb::integration::utils::{
 };
 use bdk::wallet::AddressIndex;
 use bitmask_core::{
-    bitcoin::{fund_vault, get_new_address, get_wallet, new_mnemonic, sign_psbt_file, sync_wallet},
+    bitcoin::{
+        fund_vault, get_new_address, get_wallet, new_mnemonic, sign_and_publish_psbt_file,
+        sync_wallet,
+    },
     rgb::{accept_transfer, create_watcher, full_transfer_asset, get_contract},
     structs::{
         AcceptRequest, FullRgbTransferRequest, PsbtFeeRequest, PsbtInputRequest, SecretString,
@@ -97,7 +100,7 @@ async fn create_dustless_transfer_with_fee_value() -> anyhow::Result<()> {
         ]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     let whatever_address = "bcrt1p76gtucrxhmn8s5622r859dpnmkj0kgfcel9xy0sz6yj84x6ppz2qk5hpsw";
@@ -232,7 +235,7 @@ async fn create_dustless_transfer_with_fee_rate() -> anyhow::Result<()> {
         ]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     // println!("{:?}", resp);
     assert!(resp.is_ok());
 

--- a/tests/rgb/integration/fungibles.rs
+++ b/tests/rgb/integration/fungibles.rs
@@ -4,7 +4,7 @@ use crate::rgb::integration::utils::{
     ISSUER_MNEMONIC, OWNER_MNEMONIC,
 };
 use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
+    bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     rgb::accept_transfer,
     structs::{AcceptRequest, SecretString, SignPsbtRequest},
 };
@@ -62,7 +62,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     let request = AcceptRequest {

--- a/tests/rgb/integration/states.rs
+++ b/tests/rgb/integration/states.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
+    bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     rgb::{accept_transfer, create_watcher, get_contract},
     structs::{AcceptRequest, DecryptedWalletData, SecretString, SignPsbtRequest, WatcherRequest},
 };
@@ -89,7 +89,7 @@ async fn check_fungible_state_after_accept_consig() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -192,7 +192,7 @@ async fn check_uda_state_after_accept_consig() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 

--- a/tests/rgb/integration/swaps.rs
+++ b/tests/rgb/integration/swaps.rs
@@ -8,7 +8,7 @@ use bitmask_core::{
         sign_psbt_file, sync_wallet,
     },
     rgb::{
-        accept_transfer, create_offer_buyer, create_offer_seller, create_swap_transfer,
+        accept_transfer, create_buyer_bid, create_seller_offer, create_swap_transfer,
         create_watcher, get_contract, verify_transfers,
     },
     structs::{
@@ -146,14 +146,13 @@ async fn create_scriptless_swap() -> anyhow::Result<()> {
         bitcoin_changes: vec![],
     };
 
-    let seller_swap_resp = create_offer_seller(&seller_sk, seller_swap_req).await;
+    let seller_swap_resp = create_seller_offer(&seller_sk, seller_swap_req).await;
     assert!(seller_swap_resp.is_ok());
 
     // 7. Create Buyer Swap Side
     let RgbOfferResponse {
         offer_id,
         contract_amount,
-        seller_psbt,
         ..
     } = seller_swap_resp?;
 
@@ -165,10 +164,9 @@ async fn create_scriptless_swap() -> anyhow::Result<()> {
         descriptor: SecretString(buyer_btc_desc),
         change_terminal: "/1/0".to_string(),
         fee: PsbtFeeRequest::Value(1000),
-        seller_psbt,
     };
 
-    let buyer_swap_resp = create_offer_buyer(&buyer_sk, buyer_swap_req).await;
+    let buyer_swap_resp = create_buyer_bid(&buyer_sk, buyer_swap_req).await;
     assert!(buyer_swap_resp.is_ok());
 
     // 8. Sign the Buyer Side
@@ -376,14 +374,13 @@ async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
         bitcoin_changes: vec![],
     };
 
-    let seller_swap_resp = create_offer_seller(&seller_sk, seller_swap_req).await;
+    let seller_swap_resp = create_seller_offer(&seller_sk, seller_swap_req).await;
     assert!(seller_swap_resp.is_ok());
 
     // 7. Create Buyer Swap Side
     let RgbOfferResponse {
         offer_id,
         contract_amount,
-        seller_psbt,
         ..
     } = seller_swap_resp?;
 
@@ -395,10 +392,9 @@ async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
         descriptor: SecretString(buyer_btc_desc),
         change_terminal: "/1/0".to_string(),
         fee: PsbtFeeRequest::Value(1000),
-        seller_psbt,
     };
 
-    let buyer_swap_resp = create_offer_buyer(&buyer_sk, buyer_swap_req).await;
+    let buyer_swap_resp = create_buyer_bid(&buyer_sk, buyer_swap_req).await;
     assert!(buyer_swap_resp.is_ok());
 
     // 8. Sign the Buyer Side

--- a/tests/rgb/integration/swaps.rs
+++ b/tests/rgb/integration/swaps.rs
@@ -1,5 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
-use crate::rgb::integration::utils::{issuer_issue_contract_v2, send_some_coins, UtxoFilter};
+use crate::rgb::integration::utils::{
+    get_uda_data, issuer_issue_contract_v2, send_some_coins, UtxoFilter,
+};
 use bitmask_core::{
     bitcoin::{
         fund_vault, get_new_address, get_wallet, new_mnemonic, sign_and_publish_psbt_file,
@@ -7,7 +9,7 @@ use bitmask_core::{
     },
     rgb::{
         accept_transfer, create_offer_buyer, create_offer_seller, create_swap_transfer,
-        create_watcher, get_contract,
+        create_watcher, get_contract, verify_transfers,
     },
     structs::{
         AcceptRequest, IssueResponse, PsbtFeeRequest, RgbBidRequest, RgbBidResponse,
@@ -230,15 +232,250 @@ async fn create_scriptless_swap() -> anyhow::Result<()> {
     let whatever_address = "bcrt1p76gtucrxhmn8s5622r859dpnmkj0kgfcel9xy0sz6yj84x6ppz2qk5hpsw";
     send_some_coins(whatever_address, "0.001").await;
 
-    // 11. Retrieve Contract (Buyer Side)
+    // 11. Retrieve Contract (Seller Side)
     let resp = get_contract(&seller_sk, &contract_id).await;
     assert!(resp.is_ok());
     assert_eq!(1, resp?.balance);
 
-    // 12. Retrieve Contract (Seller Side)
+    // 12. Retrieve Contract (Buyer Side)
     let resp = get_contract(&buyer_sk, &contract_id).await;
     assert!(resp.is_ok());
     assert_eq!(4, resp?.balance);
+
+    // 13. Verify transfers (Seller Side)
+    let resp = verify_transfers(&seller_sk).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.transfers.len());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
+    // 1. Initial Setup
+    let seller_keys = new_mnemonic(&SecretString("".to_string())).await?;
+    let buyer_keys = new_mnemonic(&SecretString("".to_string())).await?;
+
+    let watcher_name = "default";
+    let issuer_sk = &seller_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: seller_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(issuer_sk, create_watch_req.clone()).await?;
+
+    let owner_sk = &buyer_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: buyer_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(owner_sk, create_watch_req.clone()).await?;
+
+    // 2. Setup Wallets (Seller)
+    let btc_address_1 = get_new_address(
+        &SecretString(seller_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.001";
+    send_some_coins(&btc_address_1, default_coins).await;
+
+    let btc_descriptor_xprv = SecretString(seller_keys.private.btc_descriptor_xprv.clone());
+    let btc_change_descriptor_xprv =
+        SecretString(seller_keys.private.btc_change_descriptor_xprv.clone());
+
+    let assets_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let assets_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let btc_wallet = get_wallet(&btc_descriptor_xprv, Some(&btc_change_descriptor_xprv)).await?;
+    sync_wallet(&btc_wallet).await?;
+
+    let fund_vault = fund_vault(
+        &btc_descriptor_xprv,
+        &btc_change_descriptor_xprv,
+        &assets_address_1,
+        &assets_address_2,
+        &uda_address_1,
+        &uda_address_2,
+        Some(1.1),
+    )
+    .await?;
+
+    // 3. Send some coins (Buyer)
+    let btc_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+    let asset_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.1";
+    send_some_coins(&btc_address_1, default_coins).await;
+    send_some_coins(&asset_address_1, default_coins).await;
+
+    // 4. Issue Contract (Seller)
+    let metadata = get_uda_data();
+    let issuer_resp = issuer_issue_contract_v2(
+        1,
+        "RGB21",
+        1,
+        false,
+        false,
+        Some(metadata),
+        None,
+        Some(UtxoFilter::with_outpoint(
+            fund_vault.udas_output.unwrap_or_default(),
+        )),
+        Some(seller_keys.clone()),
+    )
+    .await?;
+    let IssueResponse {
+        contract_id, iface, ..
+    } = issuer_resp[0].clone();
+
+    // 5. Create Seller Swap Side
+    let contract_amount = 1;
+    let seller_sk = seller_keys.private.nostr_prv.clone();
+    let bitcoin_price: u64 = 100000;
+    let seller_asset_desc = seller_keys.public.rgb_udas_descriptor_xpub.clone();
+    let seller_swap_req = RgbOfferRequest {
+        contract_id: contract_id.clone(),
+        iface,
+        contract_amount,
+        bitcoin_price,
+        descriptor: SecretString(seller_asset_desc),
+        change_terminal: "/21/1".to_string(),
+        bitcoin_changes: vec![],
+    };
+
+    let seller_swap_resp = create_offer_seller(&seller_sk, seller_swap_req).await;
+    assert!(seller_swap_resp.is_ok());
+
+    // 7. Create Buyer Swap Side
+    let RgbOfferResponse {
+        offer_id,
+        contract_amount,
+        seller_psbt,
+        ..
+    } = seller_swap_resp?;
+
+    let buyer_sk = buyer_keys.private.nostr_prv.clone();
+    let buyer_btc_desc = buyer_keys.public.btc_descriptor_xpub.clone();
+    let buyer_swap_req = RgbBidRequest {
+        offer_id: offer_id.clone(),
+        asset_amount: contract_amount,
+        descriptor: SecretString(buyer_btc_desc),
+        change_terminal: "/1/0".to_string(),
+        fee: PsbtFeeRequest::Value(1000),
+        seller_psbt,
+    };
+
+    let buyer_swap_resp = create_offer_buyer(&buyer_sk, buyer_swap_req).await;
+    assert!(buyer_swap_resp.is_ok());
+
+    // 8. Sign the Buyer Side
+    let RgbBidResponse {
+        bid_id, swap_psbt, ..
+    } = buyer_swap_resp?;
+    let request = SignPsbtRequest {
+        psbt: swap_psbt,
+        descriptors: vec![
+            SecretString(buyer_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(buyer_keys.private.btc_change_descriptor_xprv.clone()),
+        ],
+    };
+    let buyer_psbt_resp = sign_psbt_file(request).await;
+    assert!(buyer_psbt_resp.is_ok());
+
+    // 9. Create Swap PSBT
+    let SignedPsbtResponse {
+        psbt: swap_psbt, ..
+    } = buyer_psbt_resp?;
+    let final_swap_req = RgbSwapRequest {
+        offer_id,
+        bid_id,
+        swap_psbt,
+    };
+
+    let final_swap_resp = create_swap_transfer(issuer_sk, final_swap_req).await;
+    assert!(final_swap_resp.is_ok());
+
+    // 8. Sign the Final PSBT
+    let RgbSwapResponse {
+        final_consig,
+        final_psbt,
+        ..
+    } = final_swap_resp?;
+
+    let request = SignPsbtRequest {
+        psbt: final_psbt.clone(),
+        descriptors: vec![
+            SecretString(seller_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.btc_change_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.rgb_udas_descriptor_xprv.clone()),
+        ],
+    };
+    let seller_psbt_resp = sign_and_publish_psbt_file(request).await;
+    assert!(seller_psbt_resp.is_ok());
+
+    // 9. Accept Consig (Buyer/Seller)
+    let all_sks = [buyer_sk.clone(), seller_sk.clone()];
+    for sk in all_sks {
+        let request = AcceptRequest {
+            consignment: final_consig.clone(),
+            force: false,
+        };
+        let resp = accept_transfer(&sk, request).await;
+        assert!(resp.is_ok());
+        assert!(resp?.valid);
+    }
+
+    // 10 Mine Some Blocks
+    let whatever_address = "bcrt1p76gtucrxhmn8s5622r859dpnmkj0kgfcel9xy0sz6yj84x6ppz2qk5hpsw";
+    send_some_coins(whatever_address, "0.001").await;
+
+    // 11. Retrieve Contract (Seller Side)
+    let resp = get_contract(&seller_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(0, resp?.balance);
+
+    // 12. Retrieve Contract (Buyer Side)
+    let resp = get_contract(&buyer_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.balance);
+
+    // 13. Verify transfers (Seller Side)
+    let resp = verify_transfers(&seller_sk).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.transfers.len());
 
     Ok(())
 }

--- a/tests/rgb/integration/swaps.rs
+++ b/tests/rgb/integration/swaps.rs
@@ -136,6 +136,9 @@ async fn create_scriptless_swap() -> anyhow::Result<()> {
     let seller_sk = seller_keys.private.nostr_prv.clone();
     let bitcoin_price: u64 = 100000;
     let seller_asset_desc = seller_keys.public.rgb_assets_descriptor_xpub.clone();
+    let expire_at = (chrono::Local::now() + chrono::Duration::minutes(5))
+        .naive_utc()
+        .timestamp();
     let seller_swap_req = RgbOfferRequest {
         contract_id: contract_id.clone(),
         iface,
@@ -144,6 +147,7 @@ async fn create_scriptless_swap() -> anyhow::Result<()> {
         descriptor: SecretString(seller_asset_desc),
         change_terminal: "/20/1".to_string(),
         bitcoin_changes: vec![],
+        expire_at: Some(expire_at),
     };
 
     let seller_swap_resp = create_seller_offer(&seller_sk, seller_swap_req).await;
@@ -364,6 +368,9 @@ async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
     let seller_sk = seller_keys.private.nostr_prv.clone();
     let bitcoin_price: u64 = 100000;
     let seller_asset_desc = seller_keys.public.rgb_udas_descriptor_xpub.clone();
+    let expire_at = (chrono::Local::now() + chrono::Duration::minutes(5))
+        .naive_utc()
+        .timestamp();
     let seller_swap_req = RgbOfferRequest {
         contract_id: contract_id.clone(),
         iface,
@@ -372,6 +379,7 @@ async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
         descriptor: SecretString(seller_asset_desc),
         change_terminal: "/21/1".to_string(),
         bitcoin_changes: vec![],
+        expire_at: Some(expire_at),
     };
 
     let seller_swap_resp = create_seller_offer(&seller_sk, seller_swap_req).await;

--- a/tests/rgb/integration/swaps.rs
+++ b/tests/rgb/integration/swaps.rs
@@ -1,0 +1,244 @@
+#![cfg(not(target_arch = "wasm32"))]
+use crate::rgb::integration::utils::{issuer_issue_contract_v2, send_some_coins, UtxoFilter};
+use bitmask_core::{
+    bitcoin::{
+        fund_vault, get_new_address, get_wallet, new_mnemonic, sign_and_publish_psbt_file,
+        sign_psbt_file, sync_wallet,
+    },
+    rgb::{
+        accept_transfer, create_offer_buyer, create_offer_seller, create_swap_transfer,
+        create_watcher, get_contract,
+    },
+    structs::{
+        AcceptRequest, IssueResponse, PsbtFeeRequest, RgbSwapBuyerRequest, RgbSwapBuyerResponse,
+        RgbSwapSellerRequest, RgbSwapSellerResponse, RgbSwapTransferRequest,
+        RgbSwapTransferResponse, SecretString, SignPsbtRequest, SignedPsbtResponse, WatcherRequest,
+    },
+};
+
+#[tokio::test]
+async fn create_scriptless_swap() -> anyhow::Result<()> {
+    // 1. Initial Setup
+    let seller_keys = new_mnemonic(&SecretString("".to_string())).await?;
+    let buyer_keys = new_mnemonic(&SecretString("".to_string())).await?;
+
+    let watcher_name = "default";
+    let issuer_sk = &seller_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: seller_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(issuer_sk, create_watch_req.clone()).await?;
+
+    let owner_sk = &buyer_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: buyer_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(owner_sk, create_watch_req.clone()).await?;
+
+    // 2. Setup Wallets (Seller)
+    let btc_address_1 = get_new_address(
+        &SecretString(seller_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.001";
+    send_some_coins(&btc_address_1, default_coins).await;
+
+    let btc_descriptor_xprv = SecretString(seller_keys.private.btc_descriptor_xprv.clone());
+    let btc_change_descriptor_xprv =
+        SecretString(seller_keys.private.btc_change_descriptor_xprv.clone());
+
+    let assets_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let assets_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let btc_wallet = get_wallet(&btc_descriptor_xprv, Some(&btc_change_descriptor_xprv)).await?;
+    sync_wallet(&btc_wallet).await?;
+
+    let fund_vault = fund_vault(
+        &btc_descriptor_xprv,
+        &btc_change_descriptor_xprv,
+        &assets_address_1,
+        &assets_address_2,
+        &uda_address_1,
+        &uda_address_2,
+        Some(1.1),
+    )
+    .await?;
+
+    // 3. Send some coins (Buyer)
+    let btc_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+    let asset_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.1";
+    send_some_coins(&btc_address_1, default_coins).await;
+    send_some_coins(&asset_address_1, default_coins).await;
+
+    // 4. Issue Contract (Seller)
+    let issuer_resp = issuer_issue_contract_v2(
+        1,
+        "RGB20",
+        5,
+        false,
+        false,
+        None,
+        None,
+        Some(UtxoFilter::with_outpoint(
+            fund_vault.assets_output.unwrap_or_default(),
+        )),
+        Some(seller_keys.clone()),
+    )
+    .await?;
+    let IssueResponse {
+        contract_id,
+        iface,
+        supply,
+        ..
+    } = issuer_resp[0].clone();
+
+    // 5. Create Seller Swap Side
+    let contract_amount = supply - 1;
+    let seller_sk = seller_keys.private.nostr_prv.clone();
+    let bitcoin_price: u64 = 100000;
+    let seller_asset_desc = seller_keys.public.rgb_assets_descriptor_xpub.clone();
+    let seller_swap_req = RgbSwapSellerRequest {
+        contract_id: contract_id.clone(),
+        iface,
+        contract_amount,
+        bitcoin_price,
+        descriptor: SecretString(seller_asset_desc),
+        change_terminal: "/20/1".to_string(),
+        bitcoin_changes: vec![],
+    };
+
+    let seller_swap_resp = create_offer_seller(&seller_sk, seller_swap_req).await;
+    assert!(seller_swap_resp.is_ok());
+
+    // 7. Create Buyer Swap Side
+    let RgbSwapSellerResponse {
+        offer_id,
+        contract_amount,
+        seller_psbt,
+        ..
+    } = seller_swap_resp?;
+
+    let buyer_sk = buyer_keys.private.nostr_prv.clone();
+    let buyer_btc_desc = buyer_keys.public.btc_descriptor_xpub.clone();
+    let buyer_swap_req = RgbSwapBuyerRequest {
+        offer_id: offer_id.clone(),
+        asset_amount: contract_amount,
+        descriptor: SecretString(buyer_btc_desc),
+        change_terminal: "/1/0".to_string(),
+        fee: PsbtFeeRequest::Value(1000),
+        seller_psbt,
+    };
+
+    let buyer_swap_resp = create_offer_buyer(&buyer_sk, buyer_swap_req).await;
+    assert!(buyer_swap_resp.is_ok());
+
+    // 8. Sign the Buyer Side
+    let RgbSwapBuyerResponse {
+        bid_id, swap_psbt, ..
+    } = buyer_swap_resp?;
+    let request = SignPsbtRequest {
+        psbt: swap_psbt,
+        descriptors: vec![
+            SecretString(buyer_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(buyer_keys.private.btc_change_descriptor_xprv.clone()),
+        ],
+    };
+    let buyer_psbt_resp = sign_psbt_file(request).await;
+    assert!(buyer_psbt_resp.is_ok());
+
+    // 9.Create Swap PSBT
+    let SignedPsbtResponse {
+        psbt: swap_psbt, ..
+    } = buyer_psbt_resp?;
+    let final_swap_req = RgbSwapTransferRequest {
+        offer_id,
+        bid_id,
+        swap_psbt,
+    };
+
+    let final_swap_resp = create_swap_transfer(issuer_sk, final_swap_req).await;
+    assert!(final_swap_resp.is_ok());
+
+    // 8. Sign the Final PSBT
+    let RgbSwapTransferResponse {
+        final_consig,
+        final_psbt,
+        ..
+    } = final_swap_resp?;
+
+    let request = SignPsbtRequest {
+        psbt: final_psbt.clone(),
+        descriptors: vec![
+            SecretString(seller_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.btc_change_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.rgb_assets_descriptor_xprv.clone()),
+        ],
+    };
+    let seller_psbt_resp = sign_and_publish_psbt_file(request).await;
+    assert!(seller_psbt_resp.is_ok());
+
+    // 9. Accept Consig (Buyer/Seller)
+    let all_sks = [buyer_sk.clone(), seller_sk.clone()];
+    for sk in all_sks {
+        let request = AcceptRequest {
+            consignment: final_consig.clone(),
+            force: false,
+        };
+        let resp = accept_transfer(&sk, request).await;
+        assert!(resp.is_ok());
+        assert!(resp?.valid);
+    }
+
+    // 10 Mine Some Blocks
+    let whatever_address = "bcrt1p76gtucrxhmn8s5622r859dpnmkj0kgfcel9xy0sz6yj84x6ppz2qk5hpsw";
+    send_some_coins(whatever_address, "0.001").await;
+
+    // 11. Retrieve Contract (Buyer Side)
+    let resp = get_contract(&seller_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.balance);
+
+    // 12. Retrieve Contract (Seller Side)
+    let resp = get_contract(&buyer_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(4, resp?.balance);
+
+    Ok(())
+}

--- a/tests/rgb/integration/transfers.rs
+++ b/tests/rgb/integration/transfers.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use bdk::wallet::AddressIndex;
 use bitmask_core::{
-    bitcoin::{get_wallet, new_mnemonic, save_mnemonic, sign_psbt_file, sync_wallet},
+    bitcoin::{get_wallet, new_mnemonic, save_mnemonic, sign_and_publish_psbt_file, sync_wallet},
     rgb::{
         accept_transfer, create_invoice, create_watcher, full_transfer_asset, get_contract, import,
         save_transfer, verify_transfers, watcher_next_address, watcher_next_utxo,
@@ -103,7 +103,7 @@ async fn allow_issuer_make_conseq_transfers() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -173,7 +173,7 @@ async fn allow_issuer_make_conseq_transfers() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -258,7 +258,7 @@ async fn allow_owner_make_conseq_transfers() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -336,7 +336,7 @@ async fn allow_owner_make_conseq_transfers() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -401,7 +401,7 @@ async fn allow_owner_make_conseq_transfers() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -517,7 +517,7 @@ async fn allow_conseq_transfers_between_tree_owners() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -593,7 +593,7 @@ async fn allow_conseq_transfers_between_tree_owners() -> anyhow::Result<()> {
         psbt: issuer_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(issuer_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 
@@ -622,7 +622,7 @@ async fn allow_conseq_transfers_between_tree_owners() -> anyhow::Result<()> {
         psbt: owner_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(owner_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 9. Accept Consig (Issuer and Another Owner Sides)
@@ -764,7 +764,7 @@ async fn allows_spend_amount_from_two_different_owners() -> anyhow::Result<()> {
         psbt: transfer_resp.psbt.clone(),
         descriptors: [SecretString(issuer_xprv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -847,7 +847,7 @@ async fn allows_spend_amount_from_two_different_owners() -> anyhow::Result<()> {
         psbt: issuer_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(issuer_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -876,7 +876,7 @@ async fn allows_spend_amount_from_two_different_owners() -> anyhow::Result<()> {
         psbt: owner_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(owner_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 9. Accept Consig (Issuer and Another Owner Sides)
@@ -956,7 +956,7 @@ async fn allows_spend_amount_from_two_different_owners() -> anyhow::Result<()> {
         psbt: another_transfer_to_issuer.psbt.clone(),
         descriptors: [SecretString(another_owner_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1071,7 +1071,7 @@ async fn allows_spend_amount_from_two_different_transitions() -> anyhow::Result<
         psbt: transfer_resp.psbt.clone(),
         descriptors: [SecretString(issuer_xprv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1154,7 +1154,7 @@ async fn allows_spend_amount_from_two_different_transitions() -> anyhow::Result<
         psbt: issuer_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(issuer_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 9. Create Transfer and Accept (Owner Side)
@@ -1182,7 +1182,7 @@ async fn allows_spend_amount_from_two_different_transitions() -> anyhow::Result<
         psbt: owner_transfer_to_another_resp.psbt.clone(),
         descriptors: [SecretString(owner_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1273,7 +1273,7 @@ async fn allows_spend_amount_from_two_different_transitions() -> anyhow::Result<
         psbt: another_transfer_to_issuer.psbt.clone(),
         descriptors: [SecretString(another_owner_xpriv)].to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1367,7 +1367,7 @@ async fn allow_issuer_make_transfer_of_two_contracts_in_same_utxo() -> anyhow::R
             issuer_keys.private.rgb_assets_descriptor_xprv.clone(),
         )],
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1434,7 +1434,7 @@ async fn allow_issuer_make_transfer_of_two_contracts_in_same_utxo() -> anyhow::R
             issuer_keys.private.rgb_assets_descriptor_xprv.clone(),
         )],
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.1").await;
 
@@ -1556,7 +1556,7 @@ async fn allow_issuer_make_transfer_of_two_contract_types_in_same_utxo() -> anyh
             issuer_keys.private.rgb_assets_descriptor_xprv.clone(),
         )],
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 3. Accept Consig (Both Sides)
@@ -1626,7 +1626,7 @@ async fn allow_issuer_make_transfer_of_two_contract_types_in_same_utxo() -> anyh
             issuer_keys.private.rgb_udas_descriptor_xprv.clone(),
         )],
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     // 7. Accept Consig (Both Side)
@@ -1968,7 +1968,7 @@ async fn allow_consecutive_full_transfer_bidirectional() -> anyhow::Result<()> {
                 SecretString(wallet_a.private.btc_change_descriptor_xprv.clone()),
             ],
         };
-        let resp = sign_psbt_file(request).await;
+        let resp = sign_and_publish_psbt_file(request).await;
         assert!(resp.is_ok());
 
         let request = AcceptRequest {
@@ -2031,7 +2031,7 @@ async fn allow_consecutive_full_transfer_bidirectional() -> anyhow::Result<()> {
                     SecretString(wallet_b.private.btc_change_descriptor_xprv.clone()),
                 ],
             };
-            let resp = sign_psbt_file(request).await;
+            let resp = sign_and_publish_psbt_file(request).await;
             assert!(resp.is_ok());
 
             let request = AcceptRequest {
@@ -2165,7 +2165,7 @@ async fn allow_save_transfer_and_verify() -> anyhow::Result<()> {
             SecretString(issuer_keys.private.btc_change_descriptor_xprv.clone()),
         ],
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
     send_some_coins(whatever_address, "0.001").await;
 

--- a/tests/rgb/integration/udas.rs
+++ b/tests/rgb/integration/udas.rs
@@ -4,7 +4,7 @@ use crate::rgb::integration::utils::{
     issuer_issue_contract_v2, UtxoFilter, ISSUER_MNEMONIC, OWNER_MNEMONIC,
 };
 use bitmask_core::{
-    bitcoin::{save_mnemonic, sign_psbt_file},
+    bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     rgb::accept_transfer,
     structs::{AcceptRequest, SecretString, SignPsbtRequest},
 };
@@ -61,7 +61,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
         )]
         .to_vec(),
     };
-    let resp = sign_psbt_file(request).await;
+    let resp = sign_and_publish_psbt_file(request).await;
     assert!(resp.is_ok());
 
     let request = AcceptRequest {

--- a/tests/rgb/unit/psbt.rs
+++ b/tests/rgb/unit/psbt.rs
@@ -32,6 +32,7 @@ async fn allow_create_psbt_file() -> anyhow::Result<()> {
         }],
         vec![],
         fee,
+        None,
         Some("/0/1".to_string()),
         None,
         &tx_resolver,

--- a/tests/rgb/web/swaps.rs
+++ b/tests/rgb/web/swaps.rs
@@ -1,0 +1,390 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![cfg(target_arch = "wasm32")]
+use std::collections::HashMap;
+use std::{assert_eq, str::FromStr, vec};
+
+use crate::rgb::web::utils::{new_block, send_coins};
+use bdk::blockchain::EsploraBlockchain;
+use bitcoin::{consensus, Transaction};
+use bitmask_core::web::constants::sleep;
+use bitmask_core::{
+    debug, info,
+    rgb::{prefetch::prefetch_resolver_txs, resolvers::ExplorerResolver},
+    structs::{
+        AssetType, BatchRgbTransferResponse, ContractResponse, ContractsResponse,
+        DecryptedWalletData, FullRgbTransferRequest, FundVaultDetails, ImportRequest,
+        InvoiceRequest, InvoiceResponse, IssueRequest, IssueResponse, NextAddressResponse,
+        NextUtxoResponse, PsbtFeeRequest, PublishedPsbtResponse, RgbBidRequest, RgbBidResponse,
+        RgbOfferRequest, RgbOfferResponse, RgbSaveTransferRequest, RgbSwapRequest, RgbSwapResponse,
+        RgbTransferRequest, RgbTransferResponse, RgbTransferStatusResponse, SecretString,
+        SignPsbtRequest, SignedPsbtResponse, WalletData, WatcherRequest, WatcherResponse,
+    },
+    web::{
+        bitcoin::{
+            decrypt_wallet, encrypt_wallet, get_assets_vault, get_new_address, get_wallet_data,
+            hash_password, new_mnemonic,
+        },
+        json_parse, resolve,
+        rgb::{
+            create_bid, create_offer, create_swap, create_watcher, full_transfer_asset,
+            get_contract, import_contract, issue_contract, list_contracts, my_bids, my_offers,
+            my_orders, psbt_sign_and_publish_file, psbt_sign_file, public_offers,
+            rgb_create_invoice, save_transfer, verify_transfers, watcher_next_address,
+            watcher_next_utxo,
+        },
+        set_panic_hook,
+    },
+};
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::*;
+use web_sys::console;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const ENCRYPTION_PASSWORD: &str = "hunter2";
+const SEED_PASSWORD: &str = "";
+
+pub struct TransferRounds {
+    pub send_amount: u64,
+    pub satoshi_price: u64,
+    pub is_issuer_sender: bool,
+}
+
+impl TransferRounds {
+    pub fn with(send_amount: u64, satoshi_price: u64, is_issuer_sender: bool) -> Self {
+        TransferRounds {
+            send_amount,
+            satoshi_price,
+            is_issuer_sender,
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+#[allow(unused_assignments)]
+async fn create_transfer_swap_flow() {
+    set_panic_hook();
+    let issuer_vault = resolve(new_mnemonic("".to_string())).await;
+    let issuer_vault: DecryptedWalletData = json_parse(&issuer_vault);
+    let owner_vault = resolve(new_mnemonic("".to_string())).await;
+    let owner_vault: DecryptedWalletData = json_parse(&owner_vault);
+
+    info!("Create Issuer Watcher");
+    let iface = "RGB20";
+    let watcher_name = "default";
+    let issuer_watcher_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: issuer_vault.public.watcher_xpub.clone(),
+        force: false,
+    };
+
+    let issuer_sk = &issuer_vault.private.nostr_prv;
+    let issuer_watcher_req = serde_wasm_bindgen::to_value(&issuer_watcher_req).expect("");
+    let watcher_resp: JsValue = resolve(create_watcher(
+        issuer_sk.clone(),
+        issuer_watcher_req.clone(),
+    ))
+    .await;
+    let watcher_resp: WatcherResponse = json_parse(&watcher_resp);
+
+    info!("Get Address");
+    let btc_address_1 = resolve(get_new_address(
+        issuer_vault.public.btc_descriptor_xpub.clone(),
+        None,
+    ))
+    .await;
+    let btc_address_1: String = json_parse(&btc_address_1);
+    debug!(format!("Issuer Show Address {}", btc_address_1));
+
+    let resp = send_coins(&btc_address_1, "1").await;
+    debug!(format!("Issuer Receive Asset {:?}", resp));
+
+    let asset_address_1 = resolve(get_new_address(
+        issuer_vault.public.rgb_assets_descriptor_xpub.clone(),
+        None,
+    ))
+    .await;
+    let asset_address_1: String = json_parse(&asset_address_1);
+    debug!(format!("Issuer Show Asset Address {}", asset_address_1));
+
+    let resp = send_coins(&asset_address_1, "1").await;
+    debug!(format!("Issuer Receive Asset Bitcoin {:?}", resp));
+
+    info!("Create Owner Watcher");
+    let owner_watcher_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: owner_vault.public.watcher_xpub.clone(),
+        force: false,
+    };
+    let owner_sk = &owner_vault.private.nostr_prv;
+    let owner_watcher_req = serde_wasm_bindgen::to_value(&owner_watcher_req).expect("");
+    let watcher_resp: JsValue = resolve(create_watcher(
+        owner_sk.to_string(),
+        owner_watcher_req.clone(),
+    ))
+    .await;
+    let watcher_resp: WatcherResponse = json_parse(&watcher_resp);
+
+    info!("Get Address");
+    let btc_address_1 = resolve(get_new_address(
+        owner_vault.public.btc_descriptor_xpub.clone(),
+        None,
+    ))
+    .await;
+    let btc_address_1: String = json_parse(&btc_address_1);
+    debug!(format!("Owner Show Address {}", btc_address_1));
+
+    let resp = send_coins(&btc_address_1, "1").await;
+    debug!(format!("Owner Receive Asset {:?}", resp));
+
+    let asset_address_1 = resolve(get_new_address(
+        owner_vault.public.rgb_assets_descriptor_xpub.clone(),
+        None,
+    ))
+    .await;
+    let asset_address_1: String = json_parse(&asset_address_1);
+    debug!(format!("Owner Show Asset Address {}", asset_address_1));
+
+    let resp = send_coins(&asset_address_1, "1").await;
+    debug!(format!("Owner Receive Asset Bitcoin {:?}", resp));
+
+    info!("Get UTXO (Owner)");
+    let next_utxo: JsValue = resolve(watcher_next_utxo(
+        owner_sk.clone(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let owner_next_utxo: NextUtxoResponse = json_parse(&next_utxo);
+    debug!(format!("Owner UTXO {:?}", owner_next_utxo.utxo));
+
+    info!("Get UTXO (Issuer)");
+    let next_utxo: JsValue = resolve(watcher_next_utxo(
+        issuer_sk.clone(),
+        watcher_name.to_string(),
+        iface.to_string(),
+    ))
+    .await;
+    let issuer_next_utxo: NextUtxoResponse = json_parse(&next_utxo);
+    debug!(format!("Issuer UTXO {:?}", issuer_next_utxo.utxo));
+
+    assert!(issuer_next_utxo.utxo.is_some());
+    assert!(owner_next_utxo.utxo.is_some());
+
+    info!("Create Contract (Issuer)");
+    let supply = 5000;
+    let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
+    let issue_seal = format!("tapret1st:{issue_utxo}");
+    let issue_req = IssueRequest {
+        ticker: "DIBA".to_string(),
+        name: "DIBA".to_string(),
+        description: "DIBA".to_string(),
+        precision: 2,
+        supply,
+        seal: issue_seal.to_owned(),
+        iface: iface.to_string(),
+        meta: None,
+    };
+
+    let issue_req = serde_wasm_bindgen::to_value(&issue_req).expect("");
+    let issue_resp: JsValue = resolve(issue_contract(issuer_sk.to_string(), issue_req)).await;
+    let issuer_resp: IssueResponse = json_parse(&issue_resp);
+
+    let mut total_issuer = supply;
+    let mut total_owner = 0;
+    let rounds = vec![TransferRounds::with(4000, 1_000, true)];
+
+    let mut sender = String::new();
+    let mut sender_sk = String::new();
+    let mut sender_desc = String::new();
+    let mut sender_keys = vec![];
+
+    let mut receiver = String::new();
+    let mut receiver_sk = String::new();
+    let mut receiver_desc = String::new();
+    let mut receiver_keys = vec![];
+
+    for (index, round) in rounds.into_iter().enumerate() {
+        if round.is_issuer_sender {
+            sender = "ISSUER".to_string();
+            sender_sk = issuer_sk.to_string();
+            sender_desc = issuer_vault.public.rgb_assets_descriptor_xpub.to_string();
+            sender_keys = vec![
+                SecretString(issuer_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+
+            receiver = "OWNER".to_string();
+            receiver_sk = owner_sk.to_string();
+            receiver_desc = owner_vault.public.rgb_assets_descriptor_xpub.to_string();
+            receiver_keys = vec![
+                SecretString(owner_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+        } else {
+            sender = "OWNER".to_string();
+            sender_sk = owner_sk.to_string();
+            sender_desc = owner_vault.public.rgb_assets_descriptor_xpub.to_string();
+            sender_keys = vec![
+                SecretString(owner_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(owner_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+
+            receiver = "ISSUER".to_string();
+            receiver_sk = issuer_sk.to_string();
+            receiver_desc = issuer_vault.public.rgb_assets_descriptor_xpub.to_string();
+            receiver_keys = vec![
+                SecretString(issuer_vault.private.rgb_assets_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_descriptor_xprv.clone()),
+                SecretString(issuer_vault.private.btc_change_descriptor_xprv.clone()),
+            ];
+        }
+
+        info!(format!(
+            ">>>> ROUND #{index} {sender} SWAP {} units to {receiver} <<<<",
+            round.send_amount
+        ));
+
+        info!(format!("Sender ({sender}) Create Offer"));
+        let sender_asset_desc = sender_desc.clone();
+        let sender_swap_req = RgbOfferRequest {
+            contract_id: issuer_resp.contract_id.clone(),
+            iface: issuer_resp.iface.clone(),
+            contract_amount: round.send_amount,
+            bitcoin_price: round.satoshi_price,
+            descriptor: SecretString(sender_asset_desc),
+            change_terminal: "/20/1".to_string(),
+            bitcoin_changes: vec![],
+        };
+        let sender_swap_req = serde_wasm_bindgen::to_value(&sender_swap_req).expect("");
+
+        let sender_swap_resp: JsValue =
+            resolve(create_offer(sender_sk.clone(), sender_swap_req)).await;
+        let sender_swap_resp: RgbOfferResponse = json_parse(&sender_swap_resp);
+
+        info!(format!("Receiver ({receiver}) Create Bid"));
+        let receiver_btc_desc = receiver_desc.clone();
+        let receiver_swap_req = RgbBidRequest {
+            offer_id: sender_swap_resp.offer_id.clone(),
+            asset_amount: round.send_amount,
+            descriptor: SecretString(receiver_btc_desc),
+            change_terminal: "/1/0".to_string(),
+            fee: PsbtFeeRequest::Value(1000),
+            seller_psbt: sender_swap_resp.seller_psbt,
+        };
+        let receiver_swap_req = serde_wasm_bindgen::to_value(&receiver_swap_req).expect("");
+
+        let receiver_swap_resp: JsValue =
+            resolve(create_bid(receiver_sk.clone(), receiver_swap_req)).await;
+        let receiver_swap_resp: RgbBidResponse = json_parse(&receiver_swap_resp);
+
+        info!(format!("Receiver ({receiver}) Sign Bid"));
+        let psbt_req = SignPsbtRequest {
+            psbt: receiver_swap_resp.swap_psbt,
+            descriptors: receiver_keys.clone(),
+        };
+
+        let receiver_psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
+        let receiver_psbt_resp: JsValue =
+            resolve(psbt_sign_file(receiver_sk.clone(), receiver_psbt_req)).await;
+        let receiver_psbt_resp: SignedPsbtResponse = json_parse(&receiver_psbt_resp);
+        debug!(format!("Sign Bid Psbt: {}", receiver_psbt_resp.sign));
+
+        info!(format!("Sender ({sender}) Create Swap"));
+        let final_swap_req = RgbSwapRequest {
+            offer_id: sender_swap_resp.offer_id.clone(),
+            bid_id: receiver_swap_resp.bid_id,
+            swap_psbt: receiver_psbt_resp.psbt,
+        };
+        let final_swap_req = serde_wasm_bindgen::to_value(&final_swap_req).expect("");
+
+        let final_swap_res: JsValue = resolve(create_swap(sender_sk.clone(), final_swap_req)).await;
+        let final_swap_res: RgbSwapResponse = json_parse(&final_swap_res);
+
+        info!(format!("Sender ({sender}) Sign Swap"));
+        let psbt_req = SignPsbtRequest {
+            psbt: final_swap_res.final_psbt,
+            descriptors: sender_keys,
+        };
+
+        let swap_psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
+        let swap_psbt_resp: JsValue =
+            resolve(psbt_sign_and_publish_file(sender_sk.clone(), swap_psbt_req)).await;
+        let swap_psbt_resp: PublishedPsbtResponse = json_parse(&swap_psbt_resp);
+        debug!(format!("Sign & Publish Psbt: {:?}", swap_psbt_resp));
+
+        info!("Create new Block");
+        let resp = new_block().await;
+        debug!(format!("Block Created: {:?}", resp));
+
+        info!(format!("Save Consig ({receiver})"));
+        let save_transfer_req = RgbSaveTransferRequest {
+            iface: issuer_resp.iface.clone(),
+            consignment: final_swap_res.final_consig.clone(),
+        };
+        let save_transfer_req = serde_wasm_bindgen::to_value(&save_transfer_req).expect("");
+        let save_transfer_resp =
+            resolve(save_transfer(receiver_sk.to_string(), save_transfer_req)).await;
+        let save_transfer_resp: RgbTransferStatusResponse = json_parse(&save_transfer_resp);
+        debug!(format!("Save Consig: {:?}", save_transfer_resp));
+
+        info!("Verify Consig (Both)");
+        let verify_transfer_resp = resolve(verify_transfers(sender_sk.clone().to_string())).await;
+        let verify_transfer_resp: BatchRgbTransferResponse = json_parse(&verify_transfer_resp);
+        debug!(format!(
+            "Verify Consig ({sender}): {:?}",
+            verify_transfer_resp
+        ));
+
+        let verify_transfer_resp = resolve(verify_transfers(receiver_sk.clone())).await;
+        let verify_transfer_resp: BatchRgbTransferResponse = json_parse(&verify_transfer_resp);
+        debug!(format!(
+            "Verify Consig ({receiver}): {:?}",
+            verify_transfer_resp
+        ));
+
+        let (sender_balance, receiver_balance) = if round.is_issuer_sender {
+            total_issuer -= round.send_amount;
+            total_owner += round.send_amount;
+            (total_issuer, total_owner)
+        } else {
+            total_issuer += round.send_amount;
+            total_owner -= round.send_amount;
+            (total_owner, total_issuer)
+        };
+
+        info!(format!("Get Contract Balancer ({sender})"));
+        let contract_resp = resolve(get_contract(
+            sender_sk.to_string(),
+            issuer_resp.contract_id.clone(),
+        ))
+        .await;
+        let contract_resp: ContractResponse = json_parse(&contract_resp);
+        debug!(format!(
+            "Contract ({sender}): {} ({})\n {:#?}",
+            contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
+        ));
+        let sender_current_balance = contract_resp.balance;
+
+        info!(format!("Get Contract Balancer ({receiver})"));
+        let contract_resp =
+            resolve(get_contract(receiver_sk, issuer_resp.contract_id.clone())).await;
+        let contract_resp: ContractResponse = json_parse(&contract_resp);
+        debug!(format!(
+            "Contract ({receiver}): {} ({})\n {:#?}",
+            contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
+        ));
+        let receiver_current_balance = contract_resp.balance;
+
+        info!(format!("<<<< ROUND #{index} Finish >>>>"));
+        assert_eq!(sender_current_balance, sender_balance);
+        assert_eq!(receiver_current_balance, receiver_balance);
+    }
+}

--- a/tests/rgb/web/swaps.rs
+++ b/tests/rgb/web/swaps.rs
@@ -253,6 +253,9 @@ async fn create_transfer_swap_flow() {
         ));
 
         info!(format!("Sender ({sender}) Create Offer"));
+        let expire_at = (chrono::Local::now() + chrono::Duration::minutes(5))
+            .naive_utc()
+            .timestamp();
         let sender_asset_desc = sender_desc.clone();
         let sender_swap_req = RgbOfferRequest {
             contract_id: issuer_resp.contract_id.clone(),
@@ -262,6 +265,7 @@ async fn create_transfer_swap_flow() {
             descriptor: SecretString(sender_asset_desc),
             change_terminal: "/20/1".to_string(),
             bitcoin_changes: vec![],
+            expire_at: Some(expire_at),
         };
         let sender_swap_req = serde_wasm_bindgen::to_value(&sender_swap_req).expect("");
 
@@ -277,7 +281,6 @@ async fn create_transfer_swap_flow() {
             descriptor: SecretString(receiver_btc_desc),
             change_terminal: "/1/0".to_string(),
             fee: PsbtFeeRequest::Value(1000),
-            seller_psbt: sender_swap_resp.seller_psbt,
         };
         let receiver_swap_req = serde_wasm_bindgen::to_value(&receiver_swap_req).expect("");
 

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -16,9 +16,9 @@ use bitmask_core::{
         AssetType, BatchRgbTransferResponse, ContractResponse, ContractsResponse,
         DecryptedWalletData, FullRgbTransferRequest, FundVaultDetails, ImportRequest,
         InvoiceRequest, InvoiceResponse, IssueRequest, IssueResponse, NextAddressResponse,
-        NextUtxoResponse, PsbtFeeRequest, RgbSaveTransferRequest, RgbTransferRequest,
-        RgbTransferResponse, RgbTransferStatusResponse, SecretString, SignPsbtRequest,
-        SignPsbtResponse, WalletData, WatcherRequest, WatcherResponse,
+        NextUtxoResponse, PsbtFeeRequest, PublishedPsbtResponse, RgbSaveTransferRequest,
+        RgbTransferRequest, RgbTransferResponse, RgbTransferStatusResponse, SecretString,
+        SignPsbtRequest, WalletData, WatcherRequest, WatcherResponse,
     },
     web::{
         bitcoin::{
@@ -316,7 +316,7 @@ async fn create_transfer_with_fee_value() {
 
         let psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
         let psbt_resp: JsValue = resolve(psbt_sign_file(sender_sk.to_string(), psbt_req)).await;
-        let psbt_resp: SignPsbtResponse = json_parse(&psbt_resp);
+        let psbt_resp: PublishedPsbtResponse = json_parse(&psbt_resp);
         debug!(format!("Sign Psbt: {:?}", psbt_resp));
 
         info!("Create new Block");
@@ -604,7 +604,7 @@ async fn create_transfer_with_fee_rate() {
 
         let psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
         let psbt_resp: JsValue = resolve(psbt_sign_file(sender_sk.to_string(), psbt_req)).await;
-        let psbt_resp: SignPsbtResponse = json_parse(&psbt_resp);
+        let psbt_resp: PublishedPsbtResponse = json_parse(&psbt_resp);
         debug!(format!("Sign Psbt: {:?}", psbt_resp));
 
         info!("Create new Block");

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -28,8 +28,8 @@ use bitmask_core::{
         json_parse, resolve,
         rgb::{
             create_watcher, full_transfer_asset, get_contract, import_contract, issue_contract,
-            list_contracts, psbt_sign_file, rgb_create_invoice, save_transfer, verify_transfers,
-            watcher_next_address, watcher_next_utxo,
+            list_contracts, psbt_sign_and_publish_file, rgb_create_invoice, save_transfer,
+            verify_transfers, watcher_next_address, watcher_next_utxo,
         },
         set_panic_hook,
     },
@@ -315,7 +315,8 @@ async fn create_transfer_with_fee_value() {
         };
 
         let psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
-        let psbt_resp: JsValue = resolve(psbt_sign_file(sender_sk.to_string(), psbt_req)).await;
+        let psbt_resp: JsValue =
+            resolve(psbt_sign_and_publish_file(sender_sk.to_string(), psbt_req)).await;
         let psbt_resp: PublishedPsbtResponse = json_parse(&psbt_resp);
         debug!(format!("Sign Psbt: {:?}", psbt_resp));
 
@@ -603,7 +604,8 @@ async fn create_transfer_with_fee_rate() {
         };
 
         let psbt_req = serde_wasm_bindgen::to_value(&psbt_req).expect("");
-        let psbt_resp: JsValue = resolve(psbt_sign_file(sender_sk.to_string(), psbt_req)).await;
+        let psbt_resp: JsValue =
+            resolve(psbt_sign_and_publish_file(sender_sk.to_string(), psbt_req)).await;
         let psbt_resp: PublishedPsbtResponse = json_parse(&psbt_resp);
         debug!(format!("Sign Psbt: {:?}", psbt_resp));
 


### PR DESCRIPTION
### **Description**

This PR allows us make RGB Swaps between two wallets.

### **How to works**

Suppose we have two users, the **seller** and the **buyer**, and both would like to swap assets and bitcoins. The users need to follow the instructions below:

1. The **seller** creates an `offer` defining the quantity of assets and price in _satoshis_.
   - The `BMC` registry the `offer` in a public orderbook.
2. The **buyer** visualizes the `public offers` and creates a `bid` based on `offer`.
   - The `BMC` registry the `bid` in a public orderbook.
   - The **buyer** sign the compose and sign psbt file.
3. The **seller** verifies with your `offer` receiving a `bid`. If yes, he creates the `swap transfer`.
   - The **seller** signs and publishes the `swap transfers` and sends the `consig file` to **buyer**.
4. Both accepted the consignment file.

### **New Concepts**
1. **Public Offers:** Now the BMC server can work with public data, which is stored via Carbonado. Today, we store users' offers to facilitate the exchange of information between them.
2. **Offers/Bids:** `Offers` are a type of order from the user who wants to sell something. While `bids` are orders from a user who wants to buy something.
3. **RGB Swaps:** This swap method is based on [RGB scriptless atomic swaps](https://github.com/orgs/LNP-BP/discussions/125), proposed by @fedsten. In summary, this technique allows us to exchange an asset from L3 (off-chain) for bitcoin that is in L1 (on-chain) privately and confidentially.
4. **Sigh Hash:** Now we can use other sighashes conditions.

### **Progress**
Create a **rgb offer** (wasm32 support).
 - [X] Allow user to create your `offer`
 - [X] Allow user to save your `offer`
 - [X] Allow the user retrieve your `offer`
 - [x]  Allow users list your `offers`

Create a  **rgb bid**  (wasm32 support).
 - [X] Allow user to create your `bid`
 - [X] Allow user to save your `bid`
 - [X] Allow user to retrieve your `bid`
 - [x]  Allow users list your `bids`

Publish a **public offer**
 - [X] Allow user to publish your `public offer`
 - [X] Allow list `public offers`
 - [X] Allow filter `public offers`
 - [x]  Allow user to remove your `public offer`

Publish a **public bid**
 - [X] Allow user to publish your `public bid`
 - [X] Allow list `public bids`
 - [X] Allow filter `public bids`
 - [x]  Allow user to remove your `public bid`

Create a **swap transfer**
 - [X] Allow user co-sign swap transfer
 - [x]  BMC update offer/bid status after swap transfer
 - [x]  BMC remove offer/bid status after **accept** swap transfer 
 - [x]  Tests with UDA

Create a **swap fee output**
- [x] Add `swap fee output` in PSBT Buyer step.

Public Data (wasm32) [1]
- [x] Allow get public data by carbonado server
- [x] Allow storage public data by carbonado server
- [x] Expose methods in web.rs

Also, the **RGB Swap** supports the latest features like dustless transactions, fee rate, and RBF coming soon.

[1] Two methods need to be included to ensure compatibility.

### **Limitations**
- Today, we need an offer to a user who can create a bid.
- Although supported, it has yet to be possible to test the partial execution of the offers. In other words, in this version, the bidder needs to acquire everything.
- There is no support for bundle-type offers, where a user can sell a series of assets in a single offer.
- There needs to be more tests to cover all sign forms. 

All current limitations are workable, I decided not to implement it now so you can start testing.

Closes #292 