### PR TITLE
RGB Swaps with presig

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -5,13 +5,13 @@ use amplify::{
 };
 use anyhow::Result;
 use autosurgeon::reconcile;
-use bitcoin::{psbt::PartiallySignedTransaction, EcdsaSighashType, Network, Txid};
+use bitcoin::{psbt::PartiallySignedTransaction, Network, Txid};
 use bitcoin_30::bip32::ExtendedPubKey;
 use bitcoin_scripts::address::AddressNetwork;
 use garde::Validate;
 
 use miniscript_crate::DescriptorPublicKey;
-use rgb::RgbDescr;
+use rgb::{RgbDescr, TerminalPath};
 use rgbstd::{
     containers::BindleContent,
     contract::ContractId,
@@ -99,7 +99,7 @@ use self::{
         prefetch_resolver_user_utxo_status, prefetch_resolver_utxos, prefetch_resolver_waddress,
         prefetch_resolver_wutxo,
     },
-    psbt::{save_commit, set_tapret_position, CreatePsbtError, EstimateFeeError},
+    psbt::{save_commit, set_tapret_position, CreatePsbtError, EstimateFeeError, PsbtNewOptions},
     structs::{RgbAccount, RgbExtractTransfer, RgbTransfer, RgbTransfers},
     swap::{
         get_public_offer, get_swap_bid, mark_bid_fill, mark_offer_fill, mark_transfer_bid,
@@ -506,16 +506,16 @@ pub async fn create_psbt(sk: &str, request: PsbtRequest) -> Result<PsbtResponse,
     };
 
     let mut rgb_account = retrieve_account(sk).await.map_err(PsbtError::IO)?;
-    let psbt = internal_create_psbt(request, true, None, &mut rgb_account, &mut resolver).await?;
+
+    let psbt = internal_create_psbt(request, &mut rgb_account, &mut resolver, None).await?;
     Ok(psbt)
 }
 
 async fn internal_create_psbt(
     request: PsbtRequest,
-    set_tapret: bool,
-    sighash: Option<EcdsaSighashType>,
     rgb_account: &mut RgbAccount,
     resolver: &mut ExplorerResolver,
+    options: Option<PsbtNewOptions>,
 ) -> Result<PsbtResponse, PsbtError> {
     if let Err(err) = request.validate(&RGBContext::default()) {
         let errors = err
@@ -551,19 +551,20 @@ async fn internal_create_psbt(
         PsbtFeeRequest::FeeRate(_) => return Err(PsbtError::NoFeeRate),
     };
 
+    let options = options.unwrap_or_default();
     let wallet = rgb_account.wallets.get("default");
     let (mut psbt_file, change_terminal) = create_rgb_psbt(
         all_inputs,
         bitcoin_changes,
         fee,
-        sighash,
         asset_terminal_change,
         wallet.cloned(),
         resolver,
+        options.clone(),
     )
     .map_err(PsbtError::Create)?;
 
-    if set_tapret {
+    if options.set_tapret {
         let pos = (psbt_file.outputs.len() - 1) as u16;
         psbt_file = set_tapret_position(psbt_file, pos).map_err(PsbtError::Create)?;
     }
@@ -681,7 +682,7 @@ pub async fn full_transfer_asset(
         asset_terminal_change: Some(change_terminal),
     };
 
-    let psbt_response = internal_create_psbt(psbt_req, true, None, &mut rgb_account, &mut resolver)
+    let psbt_response = internal_create_psbt(psbt_req, &mut rgb_account, &mut resolver, None)
         .await
         .map_err(TransferError::Create)?;
 
@@ -916,41 +917,14 @@ pub async fn create_seller_offer(
         _ => return Err(RgbSwapError::NoWatcher),
     };
 
-    let (allocations, asset_inputs, bitcoin_inputs, bitcoin_changes) =
-        prebuild_seller_swap(request.clone(), &mut stock, &mut rgb_wallet, &mut resolver).await?;
-
-    rgb_account
-        .wallets
-        .insert(RGB_DEFAULT_NAME.to_owned(), rgb_wallet.clone());
-
     let RgbOfferRequest {
         contract_id,
         contract_amount,
         bitcoin_price,
-        change_terminal,
         iface,
         expire_at,
         ..
-    } = request;
-
-    let psbt_req = PsbtRequest {
-        fee: PsbtFeeRequest::Value(0),
-        asset_inputs,
-        bitcoin_inputs,
-        bitcoin_changes,
-        asset_descriptor_change: None,
-        asset_terminal_change: Some(change_terminal),
-    };
-
-    let seller_psbt = internal_create_psbt(
-        psbt_req,
-        true,
-        Some(EcdsaSighashType::SinglePlusAnyoneCanPay),
-        &mut rgb_account,
-        &mut resolver,
-    )
-    .await
-    .map_err(RgbSwapError::Create)?;
+    } = request.clone();
 
     let iface_index = match iface.to_uppercase().as_str() {
         "RGB20" => AssetType::RGB20,
@@ -961,15 +935,39 @@ pub async fn create_seller_offer(
     let network = AddressNetwork::from(network);
 
     let seller_address = next_address(iface_index, rgb_wallet.clone(), network)
-        .map_err(|op| RgbSwapError::WrongAddress(op.to_string()))?
-        .address;
+        .map_err(|op| RgbSwapError::WrongAddress(op.to_string()))?;
+
+    let TerminalPath { app, index } = seller_address.terminal;
+    let change_terminal = format!("/{app}/{index}");
+
+    let (allocations, asset_inputs, bitcoin_inputs, bitcoin_changes) =
+        prebuild_seller_swap(request, &mut stock, &mut rgb_wallet, &mut resolver).await?;
+
+    rgb_account
+        .wallets
+        .insert(RGB_DEFAULT_NAME.to_owned(), rgb_wallet.clone());
+
+    let psbt_req = PsbtRequest {
+        fee: PsbtFeeRequest::Value(0),
+        asset_inputs,
+        bitcoin_inputs,
+        bitcoin_changes,
+        asset_descriptor_change: None,
+        asset_terminal_change: Some(change_terminal),
+    };
+
+    let options = PsbtNewOptions::set_inflaction(bitcoin_price);
+    let seller_psbt =
+        internal_create_psbt(psbt_req, &mut rgb_account, &mut resolver, Some(options))
+            .await
+            .map_err(RgbSwapError::Create)?;
 
     let new_offer = RgbOffer::new(
         sk.to_string(),
         contract_id.clone(),
         iface.clone(),
         allocations,
-        seller_address,
+        seller_address.address,
         bitcoin_price,
         seller_psbt.psbt.clone(),
         expire_at,
@@ -1121,15 +1119,15 @@ pub async fn create_buyer_bid(
         asset_terminal_change: Some(change_terminal.clone()),
     };
 
-    let buyer_psbt = internal_create_psbt(
-        psbt_req,
-        false,
-        Some(EcdsaSighashType::SinglePlusAnyoneCanPay),
-        &mut rgb_account,
-        &mut resolver,
-    )
-    .await
-    .map_err(RgbSwapError::Create)?;
+    let options = PsbtNewOptions {
+        set_tapret: false,
+        check_inflation: true,
+        ..Default::default()
+    };
+
+    let buyer_psbt = internal_create_psbt(psbt_req, &mut rgb_account, &mut resolver, Some(options))
+        .await
+        .map_err(RgbSwapError::Create)?;
 
     new_bid.buyer_psbt = buyer_psbt.psbt.clone();
 
@@ -1147,6 +1145,7 @@ pub async fn create_buyer_bid(
 
     let seller_psbt = Psbt::from_str(&offer.seller_psbt)
         .map_err(|op| RgbSwapError::WrongPsbtSeller(op.to_string()))?;
+
     let buyer_psbt = Psbt::from_str(&buyer_psbt.psbt)
         .map_err(|op| RgbSwapError::WrongPsbtBuyer(op.to_string()))?;
 

--- a/src/rgb/prebuild.rs
+++ b/src/rgb/prebuild.rs
@@ -20,7 +20,7 @@ use crate::{
     constants::{get_marketplace_fee_percentage, NETWORK},
     structs::{
         AllocationDetail, AllocationValue, AssetType, FullRgbTransferRequest, PsbtFeeRequest,
-        PsbtInputRequest, RgbBidRequest, RgbOfferRequest, SecretString,
+        PsbtInputRequest, PsbtSigHashRequest, RgbBidRequest, RgbOfferRequest, SecretString,
     },
     validators::RGBContext,
 };
@@ -197,6 +197,7 @@ pub async fn prebuild_transfer_asset(
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation,
                     tapret: None,
+                    sigh_hash: None,
                 };
                 if !assets_inputs
                     .clone()
@@ -223,6 +224,7 @@ pub async fn prebuild_transfer_asset(
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation,
                     tapret: None,
+                    sigh_hash: None,
                 };
                 if !assets_inputs
                     .clone()
@@ -291,6 +293,7 @@ pub async fn prebuild_transfer_asset(
                         utxo: utxo.outpoint.to_string(),
                         utxo_terminal: format!("/{app}/{index}"),
                         tapret: None,
+                        sigh_hash: None,
                     };
                     if !bitcoin_inputs
                         .clone()
@@ -319,6 +322,7 @@ pub async fn prebuild_transfer_asset(
                         utxo: utxo.outpoint.to_string(),
                         utxo_terminal: format!("/{app}/{index}"),
                         tapret: None,
+                        sigh_hash: None,
                     };
                     if !bitcoin_inputs
                         .clone()
@@ -495,8 +499,6 @@ pub async fn prebuild_seller_swap(
     let mut assets_inputs = vec![];
     let mut assets_allocs = vec![];
 
-    let mut rng = StdRng::from_entropy();
-    let rnd_amount = rng.gen_range(600..1500);
     let mut total_asset_bitcoin_unspend: u64 = 0;
     for alloc in allocations.iter() {
         match alloc.value {
@@ -509,6 +511,7 @@ pub async fn prebuild_seller_swap(
                     descriptor: universal_desc.clone(),
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation.to_string(),
+                    sigh_hash: Some(PsbtSigHashRequest::SinglePlusAnyoneCanPay),
                     tapret: None,
                 };
                 if !assets_inputs
@@ -536,6 +539,7 @@ pub async fn prebuild_seller_swap(
                     descriptor: universal_desc.clone(),
                     utxo: alloc.utxo.clone(),
                     utxo_terminal: alloc.derivation.to_string(),
+                    sigh_hash: Some(PsbtSigHashRequest::SinglePlusAnyoneCanPay),
                     tapret: None,
                 };
                 if !assets_inputs
@@ -593,7 +597,7 @@ pub async fn prebuild_seller_swap(
     }
 
     let mut bitcoin_total = total_asset_bitcoin_unspend;
-    let total_spendable = rnd_amount + total_bitcoin_spend;
+    let total_spendable = total_bitcoin_spend;
 
     for utxo in all_unspents {
         if bitcoin_total > total_spendable {
@@ -604,6 +608,7 @@ pub async fn prebuild_seller_swap(
                 descriptor: universal_desc.clone(),
                 utxo: utxo.outpoint.to_string(),
                 utxo_terminal: format!("/{app}/{index}"),
+                sigh_hash: Some(PsbtSigHashRequest::SinglePlusAnyoneCanPay),
                 tapret: None,
             };
             if !bitcoin_inputs
@@ -730,7 +735,7 @@ pub async fn prebuild_buyer_swap(
     let mut bitcoin_changes = vec![offer_change];
 
     let mut bitcoin_total = 0;
-    let mut total_spendable = offer.bitcoin_price;
+    let mut total_spendable = bitcoin_price;
 
     // Swap Fee
     if let Some(swap_fee_address) = get_swap_new_address()
@@ -764,6 +769,7 @@ pub async fn prebuild_buyer_swap(
                         descriptor: universal_desc.clone(),
                         utxo: utxo.outpoint.to_string(),
                         utxo_terminal: format!("/{app}/{index}"),
+                        sigh_hash: Some(PsbtSigHashRequest::NonePlusAnyoneCanPay),
                         tapret: None,
                     };
                     if !bitcoin_inputs
@@ -792,6 +798,7 @@ pub async fn prebuild_buyer_swap(
                         descriptor: universal_desc.clone(),
                         utxo: utxo.outpoint.to_string(),
                         utxo_terminal: format!("/{app}/{index}"),
+                        sigh_hash: Some(PsbtSigHashRequest::NonePlusAnyoneCanPay),
                         tapret: None,
                     };
                     if !bitcoin_inputs

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -256,7 +256,25 @@ pub fn extract_commit(psbt: Psbt) -> Result<(Outpoint, Vec<u8>), DbcPsbtError> {
     }
 }
 
-pub fn save_commit(outpoint: Outpoint, commit: Vec<u8>, terminal: &str, wallet: &mut RgbWallet) {
+pub fn save_tap_commit_str(outpoint: &str, commit: &str, terminal: &str, wallet: &mut RgbWallet) {
+    let outpoint = OutPoint::from_str(outpoint).expect("invalid outpoint parse");
+
+    let outpoint = Outpoint::new(
+        bp::Txid::from_str(&outpoint.txid.to_hex()).expect("invalid outpoint parse"),
+        outpoint.vout,
+    );
+
+    let commit = Vec::<u8>::from_hex(commit).expect("invalid tap commit parse");
+
+    save_tap_commit(outpoint, commit, terminal, wallet);
+}
+
+pub fn save_tap_commit(
+    outpoint: Outpoint,
+    commit: Vec<u8>,
+    terminal: &str,
+    wallet: &mut RgbWallet,
+) {
     let descr = wallet.descr.clone();
     let RgbDescr::Tapret(mut tapret) = descr;
     let derive: Vec<&str> = terminal.split('/').filter(|s| !s.is_empty()).collect();

--- a/src/rgb/psbt.rs
+++ b/src/rgb/psbt.rs
@@ -1,21 +1,28 @@
-use std::str::FromStr;
+use std::{collections::BTreeSet, str::FromStr};
 
 use amplify::hex::{FromHex, ToHex};
 use bdk::FeeRate;
 use bitcoin::{
-    hashes::sha256,
+    blockdata::opcodes,
+    hashes::{sha256, Hash},
+    psbt::TapTree,
+    schnorr::TapTweak,
     secp256k1::SECP256K1,
-    util::bip32::{self, Fingerprint},
+    util::{
+        bip32::{self, Fingerprint},
+        taproot::{LeafVersion, TapBranchHash, TapLeafHash, TaprootBuilder, TaprootBuilderError},
+    },
+    TxIn, TxOut, Txid,
 };
 use bitcoin::{EcdsaSighashType, OutPoint, Script, XOnlyPublicKey};
 // TODO: Incompatible versions between RGB and Descriptor Wallet
-use bitcoin_30::{secp256k1::SECP256K1 as SECP256K1_30, taproot::TaprootBuilder, ScriptBuf};
+use bitcoin_30::{secp256k1::SECP256K1 as SECP256K1_30, ScriptBuf};
 use bitcoin_blockchain::locks::SeqNo;
 use bitcoin_scripts::PubkeyScript;
 use bp::{dbc::tapret::TapretCommitment, Outpoint, TapScript, Vout};
 use commit_verify::{mpc::Commitment, CommitVerify};
-use miniscript_crate::Descriptor;
-use psbt::{ProprietaryKey, ProprietaryKeyType};
+use miniscript_crate::{Descriptor, ForEachKey, ToPublicKey};
+use psbt::{ProprietaryKey, ProprietaryKeyType, PsbtVersion};
 use rgb::{
     psbt::{
         DbcPsbtError, TapretKeyError, PSBT_OUT_TAPRET_COMMITMENT, PSBT_OUT_TAPRET_HOST,
@@ -24,16 +31,16 @@ use rgb::{
     DeriveInfo, MiningStatus, Resolver, RgbDescr, RgbWallet, TerminalPath, Utxo,
 };
 use wallet::{
-    descriptors::{derive::DeriveDescriptor, InputDescriptor},
-    hd::{DerivationAccount, DerivationSubpath, UnhardenedIndex},
-    onchain::ResolveTx,
+    descriptors::{self, derive::DeriveDescriptor, InputDescriptor},
+    hd::{DerivationAccount, DerivationSubpath, DeriveError, UnhardenedIndex},
+    onchain::{ResolveTx, TxResolverError},
     psbt::{ProprietaryKeyDescriptor, ProprietaryKeyError, ProprietaryKeyLocation, Psbt},
 };
 
 use crate::{
     debug, info,
     rgb::{constants::RGB_PSBT_TAPRET, structs::AddressAmount},
-    structs::{AssetType, PsbtInputRequest},
+    structs::{AssetType, PsbtInputRequest, PsbtSigHashRequest},
 };
 
 use crate::rgb::structs::AddressFormatParseError;
@@ -87,10 +94,10 @@ pub fn create_psbt(
     psbt_inputs: Vec<PsbtInputRequest>,
     psbt_outputs: Vec<String>,
     bitcoin_fee: u64,
-    sighash: Option<EcdsaSighashType>,
     terminal_change: Option<String>,
     wallet: Option<RgbWallet>,
     tx_resolver: &impl ResolveTx,
+    options: PsbtNewOptions,
 ) -> Result<(Psbt, String), CreatePsbtError> {
     if psbt_inputs.is_empty() {
         return Err(CreatePsbtError::EmptyInputs);
@@ -125,7 +132,6 @@ pub fn create_psbt(
         let new_input = InputDescriptor::resolve_psbt_input(
             psbt_input,
             global_descriptor.clone(),
-            sighash,
             wallet.clone(),
             tx_resolver,
         )
@@ -156,13 +162,14 @@ pub fn create_psbt(
             .map_err(CreatePsbtError::WrongTerminal)?;
     }
 
-    let psbt = Psbt::construct(
+    let psbt = Psbt::new(
         global_descriptor,
         &inputs,
         &outputs,
         change_index.to_vec(),
         bitcoin_fee,
         tx_resolver,
+        options,
     )
     .map_err(|op| CreatePsbtError::Incomplete(op.to_string()))?;
 
@@ -386,7 +393,6 @@ where
         let new_input = InputDescriptor::resolve_psbt_input(
             psbt_input,
             global_descriptor.clone(),
-            None,
             Some(wallet.clone()),
             resolver,
         )
@@ -447,7 +453,6 @@ pub trait PsbtInputEx<T> {
     fn resolve_psbt_input(
         psbt_input: PsbtInputRequest,
         descriptor: Descriptor<DerivationAccount>,
-        sighash: Option<EcdsaSighashType>,
         wallet: Option<RgbWallet>,
         tx_resolver: &impl ResolveTx,
     ) -> Result<T, Self::Error>;
@@ -459,16 +464,11 @@ impl PsbtInputEx<InputDescriptor> for InputDescriptor {
     fn resolve_psbt_input(
         psbt_input: PsbtInputRequest,
         descriptor: Descriptor<DerivationAccount>,
-        sighash: Option<EcdsaSighashType>,
         wallet: Option<RgbWallet>,
         tx_resolver: &impl ResolveTx,
     ) -> Result<Self, Self::Error> {
+        let sighash: PsbtSigHashRequest = psbt_input.sigh_hash.unwrap_or_default();
         let outpoint: OutPoint = psbt_input.utxo.parse().expect("invalid outpoint parse");
-
-        let sighash = match sighash {
-            Some(ty) => ty,
-            None => EcdsaSighashType::All,
-        };
 
         let mut input: InputDescriptor = InputDescriptor {
             outpoint,
@@ -478,7 +478,7 @@ impl PsbtInputEx<InputDescriptor> for InputDescriptor {
                 .map_err(|_| PsbtInputError::WrongTerminal)?,
             seq_no: SeqNo::default(),
             tweak: None,
-            sighash_type: sighash,
+            sighash_type: EcdsaSighashType::from_consensus(sighash as u32),
         };
 
         // Verify TapTweak (User Input or Watcher inspect)
@@ -560,9 +560,10 @@ fn complete_input_desc(
 
                         let tap_tweak = ScriptBuf::from_bytes(TapScript::commit(tweak).to_vec());
 
-                        if let Ok(tap_builder) = TaprootBuilder::with_capacity(1)
-                            .add_leaf(0, tap_tweak)
-                            .map_err(|op| PsbtInputError::WrongWatcherTweak(op.to_string()))
+                        if let Ok(tap_builder) =
+                            bitcoin_30::taproot::TaprootBuilder::with_capacity(1)
+                                .add_leaf(0, tap_tweak)
+                                .map_err(|op| PsbtInputError::WrongWatcherTweak(op.to_string()))
                         {
                             // TODO: Incompatible versions between RGB and Descriptor Wallet
                             let xonly_30 =
@@ -605,5 +606,412 @@ fn complete_input_desc(
         Err(PsbtInputError::WrongScript(
             "derived scriptPubkey does not match transaction scriptPubkey".to_string(),
         ))
+    }
+}
+
+pub trait PsbtEx<T> {
+    type Error: std::error::Error;
+
+    fn new<'inputs, 'outputs>(
+        descriptor: &Descriptor<DerivationAccount>,
+        inputs: impl IntoIterator<Item = &'inputs InputDescriptor>,
+        outputs: impl IntoIterator<Item = &'outputs (PubkeyScript, u64)>,
+        change_index: Vec<UnhardenedIndex>,
+        fee: u64,
+        tx_resolver: &impl ResolveTx,
+        options: PsbtNewOptions,
+    ) -> Result<T, Self::Error>;
+}
+
+#[derive(Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub enum PsbtConstructError {
+    /// unable to construct PSBT due to one of transaction inputs is not known
+    #[from]
+    ResolvingTx(TxResolverError),
+
+    /// unable to construct PSBT due to failing key derivetion derivation
+    #[from]
+    Derive(DeriveError),
+
+    /// unable to construct PSBT due to spent transaction {0} not having
+    /// referenced output #{1}
+    OutputUnknown(Txid, u32),
+
+    /// derived scriptPubkey `{3}` does not match transaction scriptPubkey
+    /// `{2}` for {0}:{1}
+    ScriptPubkeyMismatch(Txid, u32, Script, Script),
+
+    /// one of PSBT outputs has invalid script data. {0}
+    #[from]
+    Miniscript(miniscript_crate::Error),
+
+    /// taproot script tree construction error. {0}
+    #[from]
+    TaprootBuilderError(TaprootBuilderError),
+
+    /// PSBT can't be constructed according to the consensus rules since
+    /// it spends more ({output} sats) than the sum of its input amounts
+    /// ({input} sats)
+    Inflation {
+        /// Amount spent: input amounts
+        input: u64,
+
+        /// Amount sent: sum of output value + transaction fee
+        output: u64,
+    },
+}
+
+#[derive(Clone, Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub struct PsbtNewOptions {
+    pub set_tapret: bool,
+    pub check_inflation: bool,
+    pub force_inflation: u64,
+}
+
+impl Default for PsbtNewOptions {
+    fn default() -> Self {
+        Self {
+            set_tapret: true,
+            check_inflation: true,
+            force_inflation: 0,
+        }
+    }
+}
+
+impl PsbtNewOptions {
+    pub fn set_inflaction(inflaction: u64) -> Self {
+        Self {
+            set_tapret: true,
+            check_inflation: false,
+            force_inflation: inflaction,
+        }
+    }
+}
+
+impl PsbtEx<Psbt> for Psbt {
+    type Error = PsbtConstructError;
+
+    fn new<'inputs, 'outputs>(
+        descriptor: &Descriptor<DerivationAccount>,
+        inputs: impl IntoIterator<Item = &'inputs InputDescriptor>,
+        outputs: impl IntoIterator<Item = &'outputs (PubkeyScript, u64)>,
+        change_index: Vec<UnhardenedIndex>,
+        fee: u64,
+        tx_resolver: &impl ResolveTx,
+        options: PsbtNewOptions,
+    ) -> Result<Psbt, PsbtConstructError> {
+        let mut xpub = bmap! {};
+        descriptor.for_each_key(|account| {
+            if let Some(key_source) = account.account_key_source() {
+                xpub.insert(account.account_xpub, key_source);
+            }
+            true
+        });
+
+        let mut total_spent = 0u64;
+        let mut psbt_inputs: Vec<psbt::Input> = vec![];
+
+        for (index, input) in inputs.into_iter().enumerate() {
+            let txid = input.outpoint.txid;
+            let mut tx = tx_resolver.resolve_tx(txid)?;
+
+            // Cut out witness data
+            for inp in &mut tx.input {
+                inp.witness = zero!();
+            }
+
+            let prev_output = tx
+                .output
+                .get(input.outpoint.vout as usize)
+                .ok_or(PsbtConstructError::OutputUnknown(txid, input.outpoint.vout))?;
+            let (script_pubkey, dtype, tr_descriptor, pretr_descriptor, tap_tree) = match descriptor
+            {
+                Descriptor::Tr(_) => {
+                    let output_descriptor = DeriveDescriptor::<XOnlyPublicKey>::derive_descriptor(
+                        descriptor,
+                        SECP256K1,
+                        &input.terminal,
+                    )?;
+
+                    if input.tweak.is_some() {
+                        let mut tap_tree: Option<TapBranchHash> = None;
+                        let mut tap_script = output_descriptor.script_pubkey();
+                        if let Descriptor::<XOnlyPublicKey>::Tr(tr_desc) = output_descriptor.clone()
+                        {
+                            if let Some((_, tweak)) = input.tweak {
+                                let merkel_tree =
+                                    TapBranchHash::from_slice(&tweak).expect("invalid taptweak");
+                                let internal_key = tr_desc.internal_key().to_x_only_pubkey();
+                                let (output_key, _) =
+                                    internal_key.tap_tweak(SECP256K1, Some(merkel_tree));
+                                let builder = bitcoin::blockdata::script::Builder::new();
+
+                                tap_tree = Some(merkel_tree);
+                                tap_script = builder
+                                    .push_opcode(opcodes::all::OP_PUSHNUM_1)
+                                    .push_slice(&output_key.serialize())
+                                    .into_script();
+                            }
+                        }
+                        (
+                            tap_script,
+                            descriptors::CompositeDescrType::from(&output_descriptor),
+                            Some(output_descriptor),
+                            None,
+                            tap_tree,
+                        )
+                    } else {
+                        (
+                            output_descriptor.script_pubkey(),
+                            descriptors::CompositeDescrType::from(&output_descriptor),
+                            Some(output_descriptor),
+                            None,
+                            None,
+                        )
+                    }
+                }
+                _ => {
+                    let output_descriptor =
+                        DeriveDescriptor::<bitcoin::PublicKey>::derive_descriptor(
+                            descriptor,
+                            SECP256K1,
+                            &input.terminal,
+                        )?;
+                    (
+                        output_descriptor.script_pubkey(),
+                        descriptors::CompositeDescrType::from(&output_descriptor),
+                        None,
+                        Some(output_descriptor),
+                        None,
+                    )
+                }
+            };
+            if prev_output.script_pubkey != script_pubkey {
+                return Err(PsbtConstructError::ScriptPubkeyMismatch(
+                    txid,
+                    input.outpoint.vout,
+                    prev_output.script_pubkey.clone(),
+                    script_pubkey,
+                ));
+            }
+            let mut bip32_derivation = bmap! {};
+            let result = descriptor.for_each_key(|account| {
+                match account.bip32_derivation(SECP256K1, &input.terminal) {
+                    Ok((pubkey, key_source)) => {
+                        bip32_derivation.insert(pubkey, key_source);
+                        true
+                    }
+                    Err(_) => false,
+                }
+            });
+            if !result {
+                return Err(DeriveError::DerivePatternMismatch.into());
+            }
+
+            total_spent += prev_output.value;
+
+            let tx_in = TxIn {
+                previous_output: input.outpoint,
+                ..Default::default()
+            };
+
+            let mut psbt_input =
+                psbt::Input::new(index, tx_in).expect("Error when contruct PSBT Input");
+            psbt_input.sequence_number = Some(input.seq_no);
+            psbt_input.bip32_derivation = bip32_derivation;
+            psbt_input.sighash_type = Some(input.sighash_type.into());
+
+            if dtype.is_segwit() {
+                psbt_input.witness_utxo = Some(prev_output.clone());
+            }
+            // This is required even in case of segwit outputs, since at least Ledger Nano X
+            // do not trust just `non_witness_utxo` data.
+            psbt_input.non_witness_utxo = Some(tx.clone());
+
+            if let Some(Descriptor::<XOnlyPublicKey>::Tr(tr)) = tr_descriptor {
+                psbt_input.bip32_derivation.clear();
+                psbt_input.tap_merkle_root = tr.spend_info().merkle_root();
+                psbt_input.tap_merkle_root = tap_tree;
+                psbt_input.tap_internal_key = Some(tr.internal_key().to_x_only_pubkey());
+                let spend_info = tr.spend_info();
+                psbt_input.tap_scripts = spend_info
+                    .as_script_map()
+                    .iter()
+                    .map(|((script, leaf_ver), _)| {
+                        (
+                            spend_info
+                                .control_block(&(script.clone(), *leaf_ver))
+                                .expect("taproot scriptmap is broken"),
+                            (script.clone(), *leaf_ver),
+                        )
+                    })
+                    .collect();
+                if let Some(taptree) = tr.taptree() {
+                    descriptor.for_each_key(|key| {
+                        let (pubkey, key_source) = key
+                            .bip32_derivation(SECP256K1, &input.terminal)
+                            .expect("failing on second pass of the same function");
+                        let pubkey = XOnlyPublicKey::from(pubkey);
+                        let mut leaves = vec![];
+                        for (_, ms) in taptree.iter() {
+                            for pk in ms.iter_pk() {
+                                if pk == pubkey {
+                                    leaves.push(TapLeafHash::from_script(
+                                        &ms.encode(),
+                                        LeafVersion::TapScript,
+                                    ));
+                                }
+                            }
+                        }
+                        let entry = psbt_input
+                            .tap_key_origins
+                            .entry(pubkey.to_x_only_pubkey())
+                            .or_insert((vec![], key_source));
+                        entry.0.extend(leaves);
+                        true
+                    });
+                }
+                descriptor.for_each_key(|key| {
+                    let (pubkey, key_source) = key
+                        .bip32_derivation(SECP256K1, &input.terminal)
+                        .expect("failing on second pass of the same function");
+                    let pubkey = XOnlyPublicKey::from(pubkey);
+                    if pubkey == *tr.internal_key() {
+                        psbt_input
+                            .tap_key_origins
+                            .entry(pubkey.to_x_only_pubkey())
+                            .or_insert((vec![], key_source));
+                    }
+                    true
+                });
+                for (leaves, _) in psbt_input.tap_key_origins.values_mut() {
+                    *leaves = leaves
+                        .iter()
+                        .cloned()
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect();
+                }
+            } else if let Some(output_descriptor) = pretr_descriptor {
+                let lock_script = output_descriptor.explicit_script()?;
+                if dtype.has_redeem_script() {
+                    psbt_input.redeem_script = Some(lock_script.clone().into());
+                }
+                if dtype.has_witness_script() {
+                    psbt_input.witness_script = Some(lock_script.into());
+                }
+            }
+
+            psbt_inputs.push(psbt_input);
+        }
+
+        let mut total_sent = 0u64;
+        let mut psbt_outputs: Vec<_> = outputs
+            .into_iter()
+            .enumerate()
+            .map(|(index, (script, amount))| {
+                total_sent += *amount;
+                let txout = TxOut {
+                    value: *amount,
+                    script_pubkey: script.clone().into(),
+                };
+                psbt::Output::new(index, txout)
+            })
+            .collect();
+
+        let change = if !options.check_inflation {
+            options.force_inflation
+        } else {
+            match total_spent.checked_sub(total_sent + fee) {
+                Some(change) => change,
+                None => {
+                    return Err(PsbtConstructError::Inflation {
+                        input: total_spent,
+                        output: total_sent + fee,
+                    })
+                }
+            }
+        };
+
+        if change > 0 {
+            let change_derivation: [UnhardenedIndex; 2] =
+                change_index.try_into().expect("invalid hardened index");
+            let mut bip32_derivation = bmap! {};
+            let bip32_derivation_fn = |account: &DerivationAccount| {
+                let (pubkey, key_source) = account
+                    .bip32_derivation(SECP256K1, change_derivation)
+                    .expect("already tested descriptor derivation mismatch");
+                bip32_derivation.insert(pubkey, key_source);
+                true
+            };
+
+            let change_txout = TxOut {
+                value: change,
+                ..Default::default()
+            };
+            let mut psbt_change_output = psbt::Output::new(psbt_outputs.len(), change_txout);
+            if let Descriptor::Tr(_) = descriptor {
+                let change_descriptor = DeriveDescriptor::<XOnlyPublicKey>::derive_descriptor(
+                    descriptor,
+                    SECP256K1,
+                    change_derivation,
+                )?;
+                let change_descriptor = match change_descriptor {
+                    Descriptor::Tr(tr) => tr,
+                    _ => unreachable!(),
+                };
+
+                psbt_change_output.script = change_descriptor.script_pubkey().into();
+                descriptor.for_each_key(bip32_derivation_fn);
+
+                let internal_key: XOnlyPublicKey =
+                    change_descriptor.internal_key().to_x_only_pubkey();
+                psbt_change_output.tap_internal_key = Some(internal_key);
+                if let Some(tree) = change_descriptor.taptree() {
+                    let mut builder = TaprootBuilder::new();
+                    for (depth, ms) in tree.iter() {
+                        builder = builder
+                            .add_leaf(depth, ms.encode())
+                            .expect("insane miniscript taptree");
+                    }
+                    psbt_change_output.tap_tree =
+                        Some(TapTree::try_from(builder).expect("non-finalized TaprootBuilder"));
+                }
+            } else {
+                let change_descriptor = DeriveDescriptor::<bitcoin::PublicKey>::derive_descriptor(
+                    descriptor,
+                    SECP256K1,
+                    change_derivation,
+                )?;
+                psbt_change_output.script = change_descriptor.script_pubkey().into();
+
+                let dtype = descriptors::CompositeDescrType::from(&change_descriptor);
+                descriptor.for_each_key(bip32_derivation_fn);
+
+                let lock_script = change_descriptor.explicit_script()?;
+                if dtype.has_redeem_script() {
+                    psbt_change_output.redeem_script = Some(lock_script.clone().into());
+                }
+                if dtype.has_witness_script() {
+                    psbt_change_output.witness_script = Some(lock_script.into());
+                }
+            }
+
+            psbt_change_output.bip32_derivation = bip32_derivation;
+            psbt_outputs.push(psbt_change_output);
+        }
+
+        Ok(Psbt {
+            psbt_version: PsbtVersion::V0,
+            tx_version: 2,
+            xpub,
+            inputs: psbt_inputs,
+            outputs: psbt_outputs,
+            fallback_locktime: None,
+            proprietary: none!(),
+            unknown: none!(),
+        })
     }
 }

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -77,6 +77,8 @@ pub struct RgbOffer {
     pub contract_id: AssetId,
     #[garde(ascii)]
     pub iface: String,
+    #[garde(ascii)]
+    pub terminal: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
@@ -89,6 +91,8 @@ pub struct RgbOffer {
     pub expire_at: Option<i64>,
     #[garde(ascii)]
     pub public: String,
+    #[garde(skip)]
+    pub presig: bool,
     #[garde(skip)]
     pub transfer_id: Option<String>,
 }
@@ -103,6 +107,8 @@ impl RgbOffer {
         seller_address: AddressCompat,
         bitcoin_price: u64,
         psbt: String,
+        presig: bool,
+        terminal: String,
         expire_at: Option<i64>,
     ) -> Self {
         let secp = Secp256k1::new();
@@ -141,7 +147,9 @@ impl RgbOffer {
             seller_psbt: psbt,
             seller_address: seller_address.to_string(),
             public: public_key.to_hex(),
+            presig,
             expire_at,
+            terminal,
             ..Default::default()
         }
     }
@@ -170,6 +178,8 @@ pub struct RgbOfferSwap {
     pub expire_at: Option<i64>,
     #[garde(ascii)]
     pub public: String,
+    #[garde(skip)]
+    pub presig: bool,
 }
 
 impl From<RgbOffer> for RgbOfferSwap {
@@ -184,6 +194,7 @@ impl From<RgbOffer> for RgbOfferSwap {
             seller_address,
             public,
             expire_at,
+            presig,
             ..
         } = value;
 
@@ -197,6 +208,7 @@ impl From<RgbOffer> for RgbOfferSwap {
             seller_address,
             public,
             expire_at,
+            presig,
         }
     }
 }
@@ -215,6 +227,8 @@ pub struct RgbBid {
     pub offer_id: OfferId,
     #[garde(skip)]
     pub contract_id: AssetId,
+    #[garde(skip)]
+    pub iface: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
@@ -227,6 +241,8 @@ pub struct RgbBid {
     pub public: String,
     #[garde(skip)]
     pub transfer_id: Option<String>,
+    #[garde(skip)]
+    pub transfer: Option<String>,
 }
 
 impl RgbBid {
@@ -278,6 +294,9 @@ pub struct RgbBidSwap {
     #[garde(ascii)]
     #[garde(length(min = 0, max = 100))]
     pub offer_id: OfferId,
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub iface: String,
     #[garde(skip)]
     pub contract_id: AssetId,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
@@ -290,6 +309,14 @@ pub struct RgbBidSwap {
     pub buyer_invoice: String,
     #[garde(ascii)]
     pub public: String,
+    #[garde(skip)]
+    pub transfer_id: Option<String>,
+    #[garde(skip)]
+    pub transfer: Option<String>,
+    #[garde(skip)]
+    pub tap_outpoint: Option<String>,
+    #[garde(skip)]
+    pub tap_commit: Option<String>,
 }
 
 impl From<RgbBid> for RgbBidSwap {
@@ -303,6 +330,9 @@ impl From<RgbBid> for RgbBidSwap {
             buyer_psbt,
             buyer_invoice,
             public,
+            transfer_id,
+            transfer,
+            iface,
             ..
         } = value;
 
@@ -310,11 +340,15 @@ impl From<RgbBid> for RgbBidSwap {
             bid_id,
             offer_id,
             contract_id,
+            iface,
             asset_amount,
             bitcoin_amount,
             buyer_psbt,
             buyer_invoice,
             public,
+            transfer_id,
+            transfer,
+            ..Default::default()
         }
     }
 }
@@ -422,6 +456,46 @@ pub async fn get_public_bid(
     Ok(public_bid)
 }
 
+pub async fn get_swap_bids_by_seller(
+    sk: &str,
+    offer: RgbOffer,
+) -> Result<Vec<RgbBidSwap>, RgbOfferErrors> {
+    let RgbOffer {
+        offer_id,
+        expire_at,
+        ..
+    } = offer;
+
+    let LocalRgbOffers { doc: _, rgb_offers } =
+        retrieve_public_offers().await.map_err(RgbOfferErrors::IO)?;
+
+    let public_bids: Vec<PublicRgbBid> = match rgb_offers.bids.get(&offer_id) {
+        Some(bids) => bids.values().cloned().collect(),
+        _ => return Err(RgbOfferErrors::NoOffer(offer_id)),
+    };
+
+    let mut swap_bids = vec![];
+    for bid in public_bids {
+        let PublicRgbBid { bid_id, public, .. } = bid.clone();
+        let secret = hex::decode(sk).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+        let secret_key =
+            SecretKey::from_slice(&secret).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+        let public_key =
+            PublicKey::from_str(&public).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+
+        let share_sk = SharedSecret::new(&public_key, &secret_key);
+        let share_sk = share_sk.display_secret().to_string();
+
+        let file_name = format!("{offer_id}-{bid_id}");
+        match retrieve_swap_offer_bid(&share_sk, &file_name, expire_at).await {
+            Ok(local_copy) => swap_bids.push(local_copy.rgb_bid),
+            _ => continue,
+        }
+    }
+
+    Ok(swap_bids)
+}
+
 pub async fn get_swap_bid(
     sk: &str,
     offer_id: String,
@@ -435,6 +509,33 @@ pub async fn get_swap_bid(
         SecretKey::from_slice(&secret).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
     let public_key =
         PublicKey::from_str(&bid.public).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+
+    let share_sk = SharedSecret::new(&public_key, &secret_key);
+    let share_sk = share_sk.display_secret().to_string();
+
+    let file_name = format!("{offer_id}-{bid_id}");
+    let LocalRgbOfferBid { rgb_bid, .. } =
+        retrieve_swap_offer_bid(&share_sk, &file_name, expire_at)
+            .await
+            .map_err(RgbOfferErrors::IO)?;
+
+    Ok(rgb_bid)
+}
+
+pub async fn get_swap_bid_by_buyer(
+    sk: &str,
+    offer_id: String,
+    bid_id: BidId,
+) -> Result<RgbBidSwap, RgbOfferErrors> {
+    let RgbOfferSwap {
+        expire_at, public, ..
+    } = get_public_offer(offer_id.clone()).await?;
+
+    let secret = hex::decode(sk).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+    let secret_key =
+        SecretKey::from_slice(&secret).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
+    let public_key =
+        PublicKey::from_str(&public).map_err(|op| RgbOfferErrors::Keys(op.to_string()))?;
 
     let share_sk = SharedSecret::new(&public_key, &secret_key);
     let share_sk = share_sk.display_secret().to_string();
@@ -624,6 +725,7 @@ pub async fn mark_transfer_bid(
         if let Some(position) = my_bids.iter().position(|x| x.bid_id == bid_id) {
             let mut offer = my_bids.swap_remove(position);
             offer.transfer_id = Some(consig_id.to_owned());
+            // offer.transfer = transfer;
 
             my_bids.insert(position, offer);
             rgb_bids.bids.insert(contract_id, my_bids);
@@ -771,7 +873,7 @@ impl PsbtSwapEx<Psbt> for Psbt {
             cmp::max(new_psbt.unsigned_tx.lock_time, other.unsigned_tx.lock_time);
 
         new_psbt.unsigned_tx.input.extend(other.unsigned_tx.input);
-
+        // new_psbt.unsigned_tx.output.extend(other.unsigned_tx.output);
         let current_outputs = new_psbt.unsigned_tx.output.clone();
         let new_outputs = other.unsigned_tx.output.clone();
         new_outputs.into_iter().for_each(|out| {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -577,6 +577,16 @@ pub struct SignedPsbtResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[derive(Validate)]
+#[garde(context(RGBContext))]
+pub struct PublishPsbtRequest {
+    /// PSBT encoded in Base64
+    #[garde(length(min = 0, max = u64::MAX))]
+    pub psbt: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct PublishedPsbtResponse {
     /// PSBT is signed?
     pub sign: bool,
@@ -1102,6 +1112,36 @@ pub struct RgbOfferResponse {
     pub seller_address: String,
     /// Seller PSBT (encoded in base64)
     pub seller_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]
+#[garde(context(RGBContext))]
+#[serde(rename_all = "camelCase")]
+#[display("{contract_id}:{offer_id}")]
+pub struct RgbOfferUpdateRequest {
+    /// The Contract ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub contract_id: String,
+    /// The Offer ID
+    #[garde(ascii)]
+    #[garde(length(min = 0, max = 100))]
+    pub offer_id: String,
+    /// Swap PSBT
+    #[garde(ascii)]
+    pub offer_psbt: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Display, Default)]
+#[serde(rename_all = "camelCase")]
+#[display("{offer_id}:{updated}")]
+pub struct RgbOfferUpdateResponse {
+    /// The Contract ID
+    pub contract_id: String,
+    /// The Offer ID
+    pub offer_id: String,
+    /// Updated?
+    pub updated: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Display, Default, Validate)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -525,6 +525,30 @@ pub struct PsbtInputRequest {
     /// Asset or Bitcoin Tweak
     #[garde(skip)]
     pub tapret: Option<String>,
+    /// Asset or Bitcoin Tweak
+    #[garde(skip)]
+    pub sigh_hash: Option<PsbtSigHashRequest>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum PsbtSigHashRequest {
+    /// 0x1: Sign all outputs.
+    #[default]
+    All = 0x01,
+    /// 0x2: Sign no outputs --- anyone can choose the destination.
+    None = 0x02,
+    /// 0x3: Sign the output whose index matches this input's index. If none exists,
+    /// sign the hash `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// (This rule is probably an unintentional C++ism, but it's consensus so we have
+    /// to follow it.)
+    Single = 0x03,
+    /// 0x81: Sign all outputs but only this input.
+    AllPlusAnyoneCanPay = 0x81,
+    /// 0x82: Sign no outputs and only this input.
+    NonePlusAnyoneCanPay = 0x82,
+    /// 0x83: Sign one output and only this input (see `Single` for what "one output" means).
+    SinglePlusAnyoneCanPay = 0x83,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -718,6 +718,21 @@ pub struct RgbTransferResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct RgbInternalTransferResponse {
+    /// Consignment ID
+    pub consig_id: String,
+    /// Consignment encoded (in hexadecimal)
+    pub consig: String,
+    /// PSBT File Information with tapret (in hexadecimal)
+    pub psbt: String,
+    /// Outpoint (used to spend output)
+    pub outpoint: String,
+    /// Tapret Commitment (used to spend output)
+    pub commit: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 #[derive(Validate)]
 #[garde(context(RGBContext))]
 pub struct AcceptRequest {
@@ -1116,6 +1131,8 @@ pub struct RgbOfferRequest {
     /// Bitcoin Change Addresses (format: {address}:{amount})
     #[garde(length(min = 0, max = 999))]
     pub bitcoin_changes: Vec<String>,
+    #[garde(skip)]
+    pub presig: bool,
     #[garde(skip)]
     pub expire_at: Option<i64>,
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,8 +1,8 @@
 use crate::structs::{
     AcceptRequest, FullRgbTransferRequest, ImportRequest, InvoiceRequest, IssueRequest,
-    PsbtRequest, ReIssueRequest, RgbBidRequest, RgbOfferRequest, RgbRemoveTransferRequest,
-    RgbSaveTransferRequest, RgbSwapRequest, RgbTransferRequest, SecretString, SignPsbtRequest,
-    WatcherRequest,
+    PsbtRequest, PublishPsbtRequest, ReIssueRequest, RgbBidRequest, RgbOfferRequest,
+    RgbRemoveTransferRequest, RgbSaveTransferRequest, RgbSwapRequest, RgbTransferRequest,
+    SecretString, SignPsbtRequest, WatcherRequest,
 };
 // use crate::{carbonado, lightning, rgb};
 
@@ -446,6 +446,20 @@ pub mod rgb {
         future_to_promise(async move {
             let psbt_req: SignPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
             match crate::bitcoin::sign_psbt_file(psbt_req).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
+    pub fn psbt_publish_file(_nostr_hex_sk: String, request: JsValue) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            let psbt_req: PublishPsbtRequest = serde_wasm_bindgen::from_value(request).unwrap();
+            match crate::bitcoin::publish_psbt_file(psbt_req).await {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/tests/rgb/integration/dustless.rs
+++ b/tests/rgb/integration/dustless.rs
@@ -236,7 +236,6 @@ async fn create_dustless_transfer_with_fee_rate() -> anyhow::Result<()> {
         .to_vec(),
     };
     let resp = sign_and_publish_psbt_file(request).await;
-    // println!("{:?}", resp);
     assert!(resp.is_ok());
 
     let request = AcceptRequest {

--- a/tests/rgb/integration/swaps.rs
+++ b/tests/rgb/integration/swaps.rs
@@ -4,17 +4,17 @@ use crate::rgb::integration::utils::{
 };
 use bitmask_core::{
     bitcoin::{
-        fund_vault, get_new_address, get_wallet, new_mnemonic, sign_and_publish_psbt_file,
-        sign_psbt_file, sync_wallet,
+        fund_vault, get_new_address, get_wallet, new_mnemonic, publish_psbt_file,
+        sign_and_publish_psbt_file, sign_psbt_file, sync_wallet,
     },
     rgb::{
         accept_transfer, create_buyer_bid, create_seller_offer, create_swap_transfer,
-        create_watcher, get_contract, verify_transfers,
+        create_watcher, get_contract, update_seller_offer, verify_transfers,
     },
     structs::{
-        AcceptRequest, IssueResponse, PsbtFeeRequest, RgbBidRequest, RgbBidResponse,
-        RgbOfferRequest, RgbOfferResponse, RgbSwapRequest, RgbSwapResponse, SecretString,
-        SignPsbtRequest, SignedPsbtResponse, WatcherRequest,
+        AcceptRequest, IssueResponse, PsbtFeeRequest, PublishPsbtRequest, RgbBidRequest,
+        RgbBidResponse, RgbOfferRequest, RgbOfferResponse, RgbOfferUpdateRequest, RgbSwapRequest,
+        RgbSwapResponse, SecretString, SignPsbtRequest, SignedPsbtResponse, WatcherRequest,
     },
 };
 
@@ -477,6 +477,254 @@ async fn create_scriptless_swap_for_uda() -> anyhow::Result<()> {
     assert_eq!(1, resp?.balance);
 
     // 13. Verify transfers (Seller Side)
+    let resp = verify_transfers(&seller_sk).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.transfers.len());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_presig_scriptless_swap() -> anyhow::Result<()> {
+    // 1. Initial Setup
+    let seller_keys = new_mnemonic(&SecretString("".to_string())).await?;
+    let buyer_keys = new_mnemonic(&SecretString("".to_string())).await?;
+
+    let watcher_name = "default";
+    let issuer_sk = &seller_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: seller_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(issuer_sk, create_watch_req.clone()).await?;
+
+    let owner_sk = &buyer_keys.private.nostr_prv;
+    let create_watch_req = WatcherRequest {
+        name: watcher_name.to_string(),
+        xpub: buyer_keys.public.watcher_xpub.clone(),
+        force: true,
+    };
+    create_watcher(owner_sk, create_watch_req.clone()).await?;
+
+    // 2. Setup Wallets (Seller)
+    let btc_address_1 = get_new_address(
+        &SecretString(seller_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.001";
+    send_some_coins(&btc_address_1, default_coins).await;
+
+    let btc_descriptor_xprv = SecretString(seller_keys.private.btc_descriptor_xprv.clone());
+    let btc_change_descriptor_xprv =
+        SecretString(seller_keys.private.btc_change_descriptor_xprv.clone());
+
+    let assets_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let assets_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_1 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let uda_address_2 = get_new_address(
+        &SecretString(seller_keys.public.rgb_udas_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let btc_wallet = get_wallet(&btc_descriptor_xprv, Some(&btc_change_descriptor_xprv)).await?;
+    sync_wallet(&btc_wallet).await?;
+
+    let fund_vault = fund_vault(
+        &btc_descriptor_xprv,
+        &btc_change_descriptor_xprv,
+        &assets_address_1,
+        &assets_address_2,
+        &uda_address_1,
+        &uda_address_2,
+        Some(1.1),
+    )
+    .await?;
+
+    // 3. Send some coins (Buyer)
+    let btc_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.btc_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+    let asset_address_1 = get_new_address(
+        &SecretString(buyer_keys.public.rgb_assets_descriptor_xpub.clone()),
+        None,
+    )
+    .await?;
+
+    let default_coins = "0.1";
+    send_some_coins(&btc_address_1, default_coins).await;
+    send_some_coins(&asset_address_1, default_coins).await;
+
+    // 4. Issue Contract (Seller)
+    let issuer_resp = issuer_issue_contract_v2(
+        1,
+        "RGB20",
+        5,
+        false,
+        false,
+        None,
+        None,
+        Some(UtxoFilter::with_outpoint(
+            fund_vault.assets_output.unwrap_or_default(),
+        )),
+        Some(seller_keys.clone()),
+    )
+    .await?;
+    let IssueResponse {
+        contract_id,
+        iface,
+        supply,
+        ..
+    } = issuer_resp[0].clone();
+
+    // 5. Create Seller Swap Side
+    let contract_amount = supply - 1;
+    let seller_sk = seller_keys.private.nostr_prv.clone();
+    let bitcoin_price: u64 = 100000;
+    let seller_asset_desc = seller_keys.public.rgb_assets_descriptor_xpub.clone();
+    let expire_at = (chrono::Local::now() + chrono::Duration::minutes(5))
+        .naive_utc()
+        .timestamp();
+    let seller_swap_req = RgbOfferRequest {
+        contract_id: contract_id.clone(),
+        iface,
+        contract_amount,
+        bitcoin_price,
+        descriptor: SecretString(seller_asset_desc),
+        change_terminal: "/20/1".to_string(),
+        bitcoin_changes: vec![],
+        expire_at: Some(expire_at),
+    };
+
+    let seller_swap_resp = create_seller_offer(&seller_sk, seller_swap_req).await;
+    assert!(seller_swap_resp.is_ok());
+
+    // 6. Sign the Seller PSBT
+    let RgbOfferResponse {
+        offer_id,
+        contract_amount,
+        seller_psbt,
+        ..
+    } = seller_swap_resp?;
+
+    let seller_psbt_req = SignPsbtRequest {
+        psbt: seller_psbt.clone(),
+        descriptors: vec![
+            SecretString(seller_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.btc_change_descriptor_xprv.clone()),
+            SecretString(seller_keys.private.rgb_assets_descriptor_xprv.clone()),
+        ],
+    };
+    let seller_psbt_resp = sign_psbt_file(seller_psbt_req).await;
+    assert!(seller_psbt_resp.is_ok());
+
+    let SignedPsbtResponse { psbt, .. } = seller_psbt_resp?;
+    let update_offer_req = RgbOfferUpdateRequest {
+        contract_id: contract_id.clone(),
+        offer_id: offer_id.clone(),
+        offer_psbt: psbt,
+    };
+    let update_offer_resp = update_seller_offer(&seller_sk, update_offer_req).await;
+    assert!(update_offer_resp.is_ok());
+
+    // 7. Create Buyer Swap Side
+    let buyer_sk = buyer_keys.private.nostr_prv.clone();
+    let buyer_btc_desc = buyer_keys.public.btc_descriptor_xpub.clone();
+    let buyer_swap_req = RgbBidRequest {
+        offer_id: offer_id.clone(),
+        asset_amount: contract_amount,
+        descriptor: SecretString(buyer_btc_desc),
+        change_terminal: "/1/0".to_string(),
+        fee: PsbtFeeRequest::Value(1000),
+    };
+
+    let buyer_swap_resp = create_buyer_bid(&buyer_sk, buyer_swap_req).await;
+    assert!(buyer_swap_resp.is_ok());
+
+    // 8. Sign the Buyer Side
+    let RgbBidResponse {
+        bid_id, swap_psbt, ..
+    } = buyer_swap_resp?;
+    let request = SignPsbtRequest {
+        psbt: swap_psbt,
+        descriptors: vec![
+            SecretString(buyer_keys.private.btc_descriptor_xprv.clone()),
+            SecretString(buyer_keys.private.btc_change_descriptor_xprv.clone()),
+        ],
+    };
+    let buyer_psbt_resp = sign_psbt_file(request).await;
+    assert!(buyer_psbt_resp.is_ok());
+
+    // 9. Create Swap PSBT
+    let SignedPsbtResponse {
+        psbt: swap_psbt, ..
+    } = buyer_psbt_resp?;
+    let final_swap_req = RgbSwapRequest {
+        offer_id,
+        bid_id,
+        swap_psbt,
+    };
+
+    let final_swap_resp = create_swap_transfer(issuer_sk, final_swap_req).await;
+    assert!(final_swap_resp.is_ok());
+
+    // 10. Publish Swap PSBT
+    let RgbSwapResponse {
+        final_consig,
+        final_psbt,
+        ..
+    } = final_swap_resp?;
+    let final_swap_req = PublishPsbtRequest { psbt: final_psbt };
+    let published_psbt_resp = publish_psbt_file(final_swap_req).await;
+    assert!(published_psbt_resp.is_ok());
+
+    // 11. Accept Consig (Buyer/Seller)
+    let all_sks = [buyer_sk.clone(), seller_sk.clone()];
+    for sk in all_sks {
+        let request = AcceptRequest {
+            consignment: final_consig.clone(),
+            force: false,
+        };
+        let resp = accept_transfer(&sk, request).await;
+        assert!(resp.is_ok());
+        assert!(resp?.valid);
+    }
+
+    // 12 Mine Some Blocks
+    let whatever_address = "bcrt1p76gtucrxhmn8s5622r859dpnmkj0kgfcel9xy0sz6yj84x6ppz2qk5hpsw";
+    send_some_coins(whatever_address, "0.001").await;
+
+    // 13. Retrieve Contract (Seller Side)
+    let resp = get_contract(&seller_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(1, resp?.balance);
+
+    // 14. Retrieve Contract (Buyer Side)
+    let resp = get_contract(&buyer_sk, &contract_id).await;
+    assert!(resp.is_ok());
+    assert_eq!(4, resp?.balance);
+
+    // 15. Verify transfers (Seller Side)
     let resp = verify_transfers(&seller_sk).await;
     assert!(resp.is_ok());
     assert_eq!(1, resp?.transfers.len());

--- a/tests/rgb/integration/utils.rs
+++ b/tests/rgb/integration/utils.rs
@@ -365,6 +365,7 @@ pub async fn create_new_psbt(
                 descriptor: SecretString(descriptor_pub.clone()),
                 utxo: allocation.utxo.to_owned(),
                 utxo_terminal: allocation.derivation,
+                sigh_hash: None,
                 tapret: None,
             })
         }
@@ -552,6 +553,7 @@ pub async fn create_new_psbt_v2(
             descriptor: SecretString(descriptor_pub.clone()),
             utxo: x.utxo.to_owned(),
             utxo_terminal: x.derivation,
+            sigh_hash: None,
             tapret: None,
         })
         .collect();

--- a/tests/rgb/unit/psbt.rs
+++ b/tests/rgb/unit/psbt.rs
@@ -4,7 +4,7 @@ use crate::rgb::unit::utils::{
 };
 use bitmask_core::{
     rgb::{
-        psbt::{create_psbt, extract_commit},
+        psbt::{create_psbt, extract_commit, PsbtNewOptions},
         transfer::pay_invoice,
     },
     structs::{PsbtInputRequest, SecretString},
@@ -28,14 +28,15 @@ async fn allow_create_psbt_file() -> anyhow::Result<()> {
             descriptor: SecretString(desc.to_string()),
             utxo: asset_utxo.to_string(),
             utxo_terminal: asset_utxo_terminal.to_string(),
+            sigh_hash: None,
             tapret: None,
         }],
         vec![],
         fee,
-        None,
         Some("/0/1".to_string()),
         None,
         &tx_resolver,
+        PsbtNewOptions::default(),
     );
     assert!(psbt.is_ok());
 

--- a/tests/rgb/web/swaps.rs
+++ b/tests/rgb/web/swaps.rs
@@ -266,6 +266,7 @@ async fn create_transfer_swap_flow() {
             change_terminal: "/20/1".to_string(),
             bitcoin_changes: vec![],
             expire_at: Some(expire_at),
+            presig: false,
         };
         let sender_swap_req = serde_wasm_bindgen::to_value(&sender_swap_req).expect("");
 


### PR DESCRIPTION
### **Description**

This PR allow the seller sign the PSBT in the **create offer** step and buyer co-sign and broadcast, without requiring third-party control.

To achievement that, we needed create a new method to construct PSBT file, without the need to have all inputs previously added, reducing the number of interactions between parties (from 2 to 3).

**How to works**
1. The **seller** creates an `offer`
   - The `BMC` registry the `offer` in a public orderbook.
2. The **seller**  and co-sign the psbt file.
   - The `BMC` updates the `offer` in a public orderbook.
3. The **buyer** retrieves the `offer`, create `bid` and complete and co-sign psbt file.
4. The **buyer** publish the the swap transaction directly.

**Improviments**
- Create extension to allow us create partial PSBTs 
   - Seller can define the value of the asset without adding inputs to it. Previously, to create a PSBT, even a partial one, it was necessary to add an amount greater than or equal to the amount of output satoshis (this is a bug);
   - This improvement reduced the amount of customizations we needed to make to BP-WG packages. Now just update amplify to 4.0
- Allow update public offer in public orderbook;
- Allow each participant define your sighash condition;


**!!! UPDATE https://github.com/diba-io/bitmask-core/pull/385/commits/a4adbce82ff4989489bc751ca500e0e5e4e585f0 !!!**

I had problems with balance consistency after swap operations, mainly because according to traditional RGB logic, the seller would be the last to work on the file and, consequently, generate the transaction and store the taptweak.

But how to do this if the buyer will be the last participant involved?

The solution for now without many changes was to share the `taptweak` via swap file so that the seller can receive it as soon as the transaction is registered.

Another problem encountered is how to guarantee that payments will be asynchronous: I basically use the swap file, where every time the user "goes online", I search the orders (offers/bids) behind pending transactions in monitoring and update them. For BME it is transparent, as this logic is in `verify_transfers`

Closes #382 