### PR TITLE
Support to Fractions

### DIFF
--- a/lib/web/rgb.ts
+++ b/lib/web/rgb.ts
@@ -327,6 +327,16 @@ export interface MediaInfo {
   source: string;
 }
 
+// In structs.rs this is called SimpleContractResponse
+export interface SimpleContractResponse {
+  /// The contract id
+  contractId: string;
+  /// The contract interface
+  ifaceId: string;
+  /// Precision of the asset
+  precision: number;
+}
+
 export interface InvoiceRequest {
   /// The contract id
   contractId: string;

--- a/lib/web/rgb.ts
+++ b/lib/web/rgb.ts
@@ -308,6 +308,8 @@ export interface ImportResponse {
   precision: number;
   /// The user contract balance
   balance: bigint;
+  /// The user contract balance
+  balance_normalized: number;
   /// The contract allocations
   allocations: AllocationDetail[];
   /// The contract state (multiple formats)
@@ -331,7 +333,7 @@ export interface InvoiceRequest {
   /// The contract interface
   iface: string;
   /// Amount of the asset
-  amount: bigint;
+  amount: string;
   /// UTXO or Blinded UTXO
   seal: string;
   /// Query parameters
@@ -664,7 +666,7 @@ export interface RgbOfferRequest {
   /// The Contract Interface
   iface: string;
   /// Contract Amount
-  contractAmount: bigint;
+  contractAmount: string;
   /// Bitcoin Price (in sats)
   bitcoinPrice: bigint;
   /// Universal Descriptor
@@ -681,7 +683,7 @@ export interface RgbOfferResponse {
   /// The Contract ID
   contractId: string;
   /// Contract Amount
-  contractAmount: bigint;
+  contractAmount: number;
   /// Bitcoin Price
   bitcoinPrice: bigint;
   /// Seller Address
@@ -694,7 +696,7 @@ export interface RgbBidRequest {
   /// The Offer ID
   offerId: string;
   /// Asset Amount
-  assetAmount: bigint;
+  assetAmount: string;
   /// Universal Descriptor
   descriptor: string;
   /// Bitcoin Terminal Change

--- a/src/bin/bitmaskd.rs
+++ b/src/bin/bitmaskd.rs
@@ -117,7 +117,7 @@ async fn self_invoice(
     let invoice = InvoiceRequest {
         contract_id: self_invoice.contract_id,
         iface: "RGB21".to_string(),
-        amount: 1,
+        amount: "1".to_string(),
         seal: invoice_seal.to_owned(),
         params: self_invoice.params,
     };

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -72,8 +72,8 @@ use crate::{
         RgbSaveTransferRequest, RgbSwapRequest, RgbSwapResponse, RgbTransferDetail,
         RgbTransferInternalParams, RgbTransferRequest, RgbTransferResponse,
         RgbTransferStatusResponse, RgbTransfersResponse, SchemaDetail, SchemasResponse,
-        TransferType, TxStatus, UDADetail, UtxoResponse, WatcherDetailResponse, WatcherRequest,
-        WatcherResponse, WatcherUtxoResponse,
+        SimpleContractResponse, TransferType, TxStatus, UDADetail, UtxoResponse,
+        WatcherDetailResponse, WatcherRequest, WatcherResponse, WatcherUtxoResponse,
     },
     validators::RGBContext,
 };
@@ -104,7 +104,10 @@ use self::{
     psbt::{
         save_tap_commit_str, set_tapret_output, CreatePsbtError, EstimateFeeError, PsbtNewOptions,
     },
-    structs::{ContractAmount, RgbAccountV1, RgbExtractTransfer, RgbTransfer, RgbTransfers},
+    structs::{
+        ContractAmount, ContractBoilerplate, RgbAccountV1, RgbExtractTransfer, RgbTransfer,
+        RgbTransfers,
+    },
     swap::{
         get_public_offer, get_swap_bid, get_swap_bid_by_buyer, get_swap_bids_by_seller,
         mark_bid_fill, mark_offer_fill, mark_transfer_bid, mark_transfer_offer, publish_public_bid,
@@ -1906,6 +1909,24 @@ pub async fn get_contract(sk: &str, contract_id: &str) -> Result<ContractRespons
     };
 
     Ok(contract)
+}
+
+pub async fn get_simple_contract(sk: &str, contract_id: &str) -> Result<SimpleContractResponse> {
+    let mut stock = retrieve_rgb_stock(sk).await?;
+    let contract_id = ContractId::from_str(contract_id)?;
+    let contract = export_boilerplate(contract_id, &mut stock)?;
+
+    let ContractBoilerplate {
+        contract_id,
+        iface_id,
+        precision,
+    } = contract;
+
+    Ok(SimpleContractResponse {
+        contract_id,
+        iface_id,
+        precision,
+    })
 }
 
 pub async fn hidden_contract(sk: &str, contract_id: &str) -> Result<ContractHiddenResponse> {

--- a/src/rgb/contract.rs
+++ b/src/rgb/contract.rs
@@ -11,11 +11,11 @@ use std::str::FromStr;
 use strict_encoding::{FieldName, StrictDeserialize, StrictSerialize};
 
 use crate::structs::{
-    AllocationValue, ContractBoilerplate, ContractFormats, ContractMeta, ContractMetadata,
-    ContractResponse, GenesisFormats, MediaInfo, UDADetail,
+    AllocationValue, ContractFormats, ContractMeta, ContractMetadata, ContractResponse,
+    GenesisFormats, MediaInfo, UDADetail,
 };
 use crate::{
-    rgb::{resolvers::ResolveSpent, wallet::contract_allocations},
+    rgb::{resolvers::ResolveSpent, structs::ContractBoilerplate, wallet::contract_allocations},
     structs::AttachInfo,
 };
 

--- a/src/rgb/structs.rs
+++ b/src/rgb/structs.rs
@@ -219,6 +219,14 @@ impl Display for ContractAmount {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
+#[display("{contract_id}:{precision}")]
+pub struct ContractBoilerplate {
+    pub contract_id: String,
+    pub iface_id: String,
+    pub precision: u8,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct RgbAccount {
     pub wallets: HashMap<String, RgbWallet>,

--- a/src/rgb/structs.rs
+++ b/src/rgb/structs.rs
@@ -1,13 +1,13 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    str::FromStr,
-};
-
 use amplify::confinement::{Confined, U32};
 use bitcoin::Address;
 use bitcoin_scripts::address::AddressCompat;
 use bp::Txid;
+use core::fmt::Display;
 use rgb::{RgbWallet, TerminalPath};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
 
 use rgbstd::containers::{Bindle, Transfer};
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,182 @@ impl FromStr for AddressAmount {
         let address = Address::from_str(split[0]).expect("invalid address format");
         let amount = u64::from_str(split[1]).expect("invalid address format");
         Ok(AddressAmount { address, amount })
+    }
+}
+
+pub struct ContractAmount {
+    pub int: u64,
+    pub fract: u64,
+    pub precision: u8,
+}
+
+impl ContractAmount {
+    /// Initialize a new contract value.
+    ///
+    /// A value ([`u64`]) combine with precision ([`u8`]), generate
+    /// a new contract value, compabitle with rgb contract value.
+    ///
+    /// Remeber: All contract amounts are represents in [`u64`].
+    /// The [`ContractAmount`] abstract the calculation.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// // Define the initial value
+    /// let amount = CoinAmount::with(5, 2);
+    ///
+    /// assert_eq!(amount.int, 5);
+    /// assert_eq!(amount.fract, 0);
+    /// assert_eq!(amount.to_value(), 500);
+    /// assert_eq!(amount.to_string(), "5");
+    /// ```
+    pub fn new(value: u64, precision: u8) -> Self {
+        let pow = 10_u64.pow(precision as u32);
+
+        let int = if value < pow { value } else { value / pow };
+        let fract = if value < pow { 0 } else { value - int * pow };
+        ContractAmount {
+            int,
+            fract,
+            precision,
+        }
+    }
+
+    /// Load a contract value.
+    ///
+    /// A value ([`u64`]) combine with precision ([`u8`]), load
+    /// a contract value, compabitle with rgb contract value.
+    ///
+    /// Remeber: All contract amounts are represents in [`u64`].
+    /// The [`ContractAmount`] abstract the calculation.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// // Define the initial value
+    /// let amount = ContractAmount::with(1100, 3);
+    ///
+    /// assert_eq!(amount.int, 1);
+    /// assert_eq!(amount.fract, 100);
+    /// assert_eq!(amount.to_value(), 1100);
+    /// assert_eq!(amount.to_string(), "1.100");
+    /// ```
+    pub fn with(value: u64, precision: u8) -> Self {
+        let pow = 10_u64.pow(precision as u32);
+        let int = value / pow;
+        let fract = value - int * pow;
+        ContractAmount {
+            int,
+            fract,
+            precision,
+        }
+    }
+
+    /// Convert a raw string representation of the
+    /// number in Contract Amount.
+    ///
+    /// A value ([`String`]) return a contract value,
+    /// compabitle with rgb contract value.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// // Define the initial value
+    /// let amount = ContractAmount::from("1.100");
+    ///
+    /// assert_eq!(amount.int, 1);
+    /// assert_eq!(amount.fract, 100);
+    /// assert_eq!(amount.to_value(), 1100);
+    /// assert_eq!(amount.to_string(), "1.100");
+    /// ```
+    pub fn from(value: String, precision: u8) -> Self {
+        let mut fract = 0;
+
+        let int = if value.contains('.') {
+            let parts = value.split('.');
+            let collection: Vec<&str> = parts.collect();
+
+            fract = collection[1].parse().unwrap();
+            let precision_repr = collection[1].len() as u8;
+            if precision_repr < precision {
+                let pow = 10_u64.pow((precision - precision_repr) as u32);
+                fract *= pow;
+            }
+
+            collection[0].parse().unwrap()
+        } else {
+            value.parse().unwrap()
+        };
+
+        ContractAmount {
+            int,
+            fract,
+            precision,
+        }
+    }
+
+    /// Convert a raw string representation of the
+    /// number in Contract Amount.
+    ///
+    /// A value ([`String`]) return a contract value,
+    /// compabitle with rgb contract value.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// // Define the initial value
+    /// let amount = ContractAmount::from_raw("1.100");
+    ///
+    /// assert_eq!(amount.int, 1);
+    /// assert_eq!(amount.fract, 100);
+    /// assert_eq!(amount.to_value(), 1100);
+    /// assert_eq!(amount.to_string(), "1.100");
+    /// ```
+    pub fn from_raw(value: String) -> Self {
+        let mut fract = 0;
+        let mut precision = 0;
+
+        let int = if value.contains('.') {
+            let parts = value.split('.');
+            let collection: Vec<&str> = parts.collect();
+
+            fract = collection[1].parse().unwrap();
+            precision = collection[1].len() as u8;
+
+            collection[0].parse().unwrap()
+        } else {
+            value.parse().unwrap()
+        };
+
+        ContractAmount {
+            int,
+            fract,
+            precision,
+        }
+    }
+
+    pub fn to_value(self) -> u64 {
+        let pow = 10_u64.pow(self.precision as u32);
+        self.int * pow + self.fract
+    }
+}
+
+impl Display for ContractAmount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let precision = self.precision as usize;
+        if precision > 0 {
+            write!(f, "{}.{:0precision$}", self.int, self.fract)
+        } else {
+            write!(f, "{}", self.int)
+        }
     }
 }
 

--- a/src/rgb/structs.rs
+++ b/src/rgb/structs.rs
@@ -264,6 +264,4 @@ pub struct RgbExtractTransfer {
     pub tx_id: Txid,
     pub transfer: Bindle<Transfer>,
     pub strict: Confined<Vec<u8>, 0, U32>,
-    pub offer_id: Option<String>,
-    pub bid_id: Option<String>,
 }

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -81,6 +81,8 @@ pub struct RgbOffer {
     pub terminal: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
+    #[garde(range(min = u8::MIN, max = u8::MAX))]
+    pub asset_precision: u8,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub bitcoin_price: u64,
     #[garde(ascii)]
@@ -104,6 +106,7 @@ impl RgbOffer {
         contract_id: String,
         iface: String,
         allocations: Vec<AllocationDetail>,
+        asset_precision: u8,
         seller_address: AddressCompat,
         bitcoin_price: u64,
         psbt: String,
@@ -143,6 +146,7 @@ impl RgbOffer {
             contract_id,
             iface,
             asset_amount,
+            asset_precision,
             bitcoin_price,
             seller_psbt: psbt,
             seller_address: seller_address.to_string(),
@@ -168,6 +172,8 @@ pub struct RgbOfferSwap {
     pub iface: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
+    #[garde(range(min = u8::MIN, max = u8::MAX))]
+    pub asset_precision: u8,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub bitcoin_price: u64,
     #[garde(ascii)]
@@ -195,6 +201,7 @@ impl From<RgbOffer> for RgbOfferSwap {
             public,
             expire_at,
             presig,
+            asset_precision,
             ..
         } = value;
 
@@ -209,6 +216,7 @@ impl From<RgbOffer> for RgbOfferSwap {
             public,
             expire_at,
             presig,
+            asset_precision,
         }
     }
 }
@@ -231,6 +239,8 @@ pub struct RgbBid {
     pub iface: String,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
+    #[garde(range(min = u8::MIN, max = u8::MAX))]
+    pub asset_precision: u8,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub bitcoin_amount: u64,
     #[garde(ascii)]
@@ -251,6 +261,7 @@ impl RgbBid {
         offer_id: OfferId,
         contract_id: AssetId,
         asset_amount: u64,
+        asset_precision: u8,
         bitcoin_price: u64,
         bitcoin_utxos: Vec<String>,
     ) -> Self {
@@ -277,6 +288,7 @@ impl RgbBid {
             offer_id,
             contract_id,
             asset_amount,
+            asset_precision,
             bitcoin_amount: bitcoin_price,
             public: public_key.to_hex(),
             ..Default::default()
@@ -301,6 +313,8 @@ pub struct RgbBidSwap {
     pub contract_id: AssetId,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub asset_amount: u64,
+    #[garde(range(min = u8::MIN, max = u8::MAX))]
+    pub asset_precision: u8,
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub bitcoin_amount: u64,
     #[garde(ascii)]
@@ -326,6 +340,7 @@ impl From<RgbBid> for RgbBidSwap {
             offer_id,
             contract_id,
             asset_amount,
+            asset_precision,
             bitcoin_amount,
             buyer_psbt,
             buyer_invoice,
@@ -342,6 +357,7 @@ impl From<RgbBid> for RgbBidSwap {
             contract_id,
             iface,
             asset_amount,
+            asset_precision,
             bitcoin_amount,
             buyer_psbt,
             buyer_invoice,

--- a/src/rgb/swap.rs
+++ b/src/rgb/swap.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use super::{
     constants::LIB_NAME_BITMASK,
     crdt::{LocalRgbOfferBid, LocalRgbOffers},
@@ -970,6 +971,7 @@ impl FromStr for OrderId {
     }
 }
 
+#[deprecated(note = "removed in favor to compatibility with other wallets")]
 #[derive(Clone, Debug, StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_BITMASK)]
 #[cfg_attr(
@@ -977,6 +979,7 @@ impl FromStr for OrderId {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate", rename_all = "camelCase")
 )]
+
 pub struct TransferSwap {
     pub offer_id: OrderId,
     pub bid_id: OrderId,
@@ -1017,6 +1020,7 @@ pub enum TransferSwapError {
     Inconclusive,
 }
 
+#[deprecated(note = "removed in favor to compatibility with other wallets")]
 pub fn extract_transfer(
     transfer: String,
 ) -> Result<(Txid, Bindle<Transfer>, OrderId, OrderId), TransferSwapError> {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -377,12 +377,14 @@ pub struct ContractResponse {
     pub created: i64,
     /// Description of the asset
     pub description: String,
-    /// Amount of the asset
+    /// Supply of the asset
     pub supply: u64,
     /// Precision of the asset
     pub precision: u8,
-    /// The user contract balance
+    /// Current balance
     pub balance: u64,
+    /// Current balance (Humanized)
+    pub balance_normalised: f64,
     /// The contract allocations
     pub allocations: Vec<AllocationDetail>,
     /// The contract state (multiple formats)
@@ -423,6 +425,14 @@ impl Default for ContractMetadata {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
+#[display("{contract_id}:{precision}")]
+pub struct ContractBoilerplate {
+    pub contract_id: String,
+    pub iface_id: String,
+    pub precision: u8,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct UDADetail {
@@ -458,8 +468,8 @@ pub struct InvoiceRequest {
     #[garde(length(min = 0, max = 32))]
     pub iface: String,
     /// Amount of the asset
-    #[garde(range(min = 0, max = u64::MAX))]
-    pub amount: u64,
+    #[garde(skip)]
+    pub amount: String,
     /// Blinded UTXO
     #[garde(ascii)]
     #[garde(custom(verify_tapret_seal))]
@@ -1126,8 +1136,8 @@ pub struct RgbOfferRequest {
     #[garde(length(min = 0, max = 32))]
     pub iface: String,
     /// Contract Amount
-    #[garde(range(min = u64::MIN, max = u64::MAX))]
-    pub contract_amount: u64,
+    #[garde(skip)]
+    pub contract_amount: String,
     /// Bitcoin Price (in sats)
     #[garde(range(min = u64::MIN, max = u64::MAX))]
     pub bitcoin_price: u64,
@@ -1155,7 +1165,7 @@ pub struct RgbOfferResponse {
     /// The Contract ID
     pub contract_id: String,
     /// Contract Amount
-    pub contract_amount: u64,
+    pub contract_amount: f64,
     /// Bitcoin Price
     pub bitcoin_price: u64,
     /// Seller Address
@@ -1204,8 +1214,8 @@ pub struct RgbBidRequest {
     #[garde(length(min = 0, max = 100))]
     pub offer_id: String,
     /// Asset Amount
-    #[garde(range(min = u64::MIN, max = u64::MAX))]
-    pub asset_amount: u64,
+    #[garde(skip)]
+    pub asset_amount: String,
     /// Universal Descriptor
     #[garde(custom(verify_descriptor))]
     pub descriptor: SecretString,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -425,14 +425,6 @@ impl Default for ContractMetadata {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
-#[display("{contract_id}:{precision}")]
-pub struct ContractBoilerplate {
-    pub contract_id: String,
-    pub iface_id: String,
-    pub precision: u8,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct UDADetail {
@@ -452,6 +444,14 @@ pub struct UDADetail {
     pub attach: Option<AttachInfo>,
     /// The contract allocations
     pub allocations: Vec<AllocationDetail>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, Serialize, Deserialize)]
+#[display("{contract_id}:{iface_id}:{precision}")]
+pub struct SimpleContractResponse {
+    pub contract_id: String,
+    pub iface_id: String,
+    pub precision: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -557,6 +557,19 @@ pub mod rgb {
         })
     }
 
+    pub fn get_simple_contract(nostr_hex_sk: String, contract_id: String) -> Promise {
+        set_panic_hook();
+
+        future_to_promise(async move {
+            match crate::rgb::get_simple_contract(&nostr_hex_sk, &contract_id).await {
+                Ok(result) => Ok(JsValue::from_string(
+                    serde_json::to_string(&result).unwrap(),
+                )),
+                Err(err) => Err(JsValue::from_string(err.to_string())),
+            }
+        })
+    }
+
     #[wasm_bindgen]
     pub fn hidden_contract(nostr_hex_sk: String, contract_id: String) -> Promise {
         set_panic_hook();

--- a/tests/rgb.rs
+++ b/tests/rgb.rs
@@ -21,6 +21,7 @@ mod rgb {
         mod fungibles;
         mod import;
         mod issue;
+        mod rbf;
         mod states;
         mod swaps;
         mod transfers;

--- a/tests/rgb/integration/accept.rs
+++ b/tests/rgb/integration/accept.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use bitmask_core::{
     bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
     rgb::{
-        create_watcher, list_transfers, remove_transfer, save_transfer, verify_transfers,
-        watcher_next_address,
+        create_watcher, list_transfers, remove_transfer, save_transfer, structs::ContractAmount,
+        verify_transfers, watcher_next_address,
     },
     structs::{
         DecryptedWalletData, RgbRemoveTransferRequest, RgbSaveTransferRequest, SecretString,
@@ -53,7 +53,7 @@ pub async fn allow_save_read_remove_transfers() -> Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
-        5,
+        ContractAmount::new(5, 2).to_value(),
         false,
         true,
         None,
@@ -68,7 +68,7 @@ pub async fn allow_save_read_remove_transfers() -> Result<()> {
     let owner_invoice = &create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        2,
+        2.00,
         owner_keys.clone(),
         None,
         Some(issuer_resp.clone().contract.strict),
@@ -179,7 +179,7 @@ pub async fn allow_save_read_remove_transfers() -> Result<()> {
 }
 
 #[tokio::test]
-pub async fn allow_save_and_accept_all_transfers() -> Result<()> {
+pub async fn accept_all_transfers() -> Result<()> {
     // 0. Retrieve all keys
     let issuer_keys: DecryptedWalletData = save_mnemonic(
         &SecretString(ISSUER_MNEMONIC.to_string()),
@@ -214,7 +214,7 @@ pub async fn allow_save_and_accept_all_transfers() -> Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
-        5,
+        ContractAmount::new(5, 2).to_value(),
         false,
         true,
         None,
@@ -229,7 +229,7 @@ pub async fn allow_save_and_accept_all_transfers() -> Result<()> {
     let owner_invoice = &create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        2,
+        2.00,
         owner_keys.clone(),
         None,
         Some(issuer_resp.clone().contract.strict),

--- a/tests/rgb/integration/dustless.rs
+++ b/tests/rgb/integration/dustless.rs
@@ -9,7 +9,9 @@ use bitmask_core::{
         fund_vault, get_new_address, get_wallet, new_mnemonic, sign_and_publish_psbt_file,
         sync_wallet,
     },
-    rgb::{accept_transfer, create_watcher, full_transfer_asset, get_contract},
+    rgb::{
+        accept_transfer, create_watcher, full_transfer_asset, get_contract, structs::ContractAmount,
+    },
     structs::{
         AcceptRequest, FullRgbTransferRequest, PsbtFeeRequest, PsbtInputRequest, SecretString,
         SignPsbtRequest, WatcherRequest,
@@ -25,7 +27,7 @@ async fn create_dustless_transfer_with_fee_value() -> anyhow::Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
-        5,
+        ContractAmount::new(5, 2).to_value(),
         false,
         true,
         None,
@@ -38,7 +40,7 @@ async fn create_dustless_transfer_with_fee_value() -> anyhow::Result<()> {
     let owner_resp = &create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        1,
+        1.0,
         owner_keys.clone(),
         None,
         Some(issuer_resp.clone().contract.strict),
@@ -192,7 +194,7 @@ async fn create_dustless_transfer_with_fee_rate() -> anyhow::Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
-        5,
+        ContractAmount::new(5, 2).to_value(),
         false,
         false,
         None,
@@ -207,7 +209,7 @@ async fn create_dustless_transfer_with_fee_rate() -> anyhow::Result<()> {
     let owner_resp = &create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        1,
+        1.0,
         owner_keys.clone(),
         None,
         Some(issuer_resp.clone().contract.strict),

--- a/tests/rgb/integration/fungibles.rs
+++ b/tests/rgb/integration/fungibles.rs
@@ -5,12 +5,12 @@ use crate::rgb::integration::utils::{
 };
 use bitmask_core::{
     bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
-    rgb::accept_transfer,
+    rgb::{accept_transfer, structs::ContractAmount},
     structs::{AcceptRequest, SecretString, SignPsbtRequest},
 };
 
 #[tokio::test]
-async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
+async fn accept_fungible_transfer() -> anyhow::Result<()> {
     let issuer_keys = save_mnemonic(
         &SecretString(ISSUER_MNEMONIC.to_string()),
         &SecretString("".to_string()),
@@ -24,7 +24,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB20",
-        5,
+        ContractAmount::new(5, 2).to_value(),
         false,
         true,
         None,
@@ -38,7 +38,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
     let owner_resp = &create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        1,
+        1.0,
         owner_keys.clone(),
         None,
         Some(issuer_resp.clone().contract.legacy),

--- a/tests/rgb/integration/rbf.rs
+++ b/tests/rgb/integration/rbf.rs
@@ -1,0 +1,103 @@
+#![cfg(not(target_arch = "wasm32"))]
+use anyhow::Result;
+use bdk::{
+    database::MemoryDatabase,
+    descriptor::IntoWalletDescriptor,
+    wallet::{tx_builder::TxOrdering, AddressIndex},
+    SignOptions, SyncOptions,
+};
+use bitcoin::{secp256k1::Secp256k1, Network};
+use bitmask_core::{
+    bitcoin::{get_blockchain, new_mnemonic},
+    structs::SecretString,
+};
+
+use crate::rgb::integration::utils::send_some_coins;
+
+#[ignore = "No longer necessary, this is a simple test to rbf with bdk"]
+#[tokio::test]
+pub async fn create_bdk_rbf_transaction() -> Result<()> {
+    // 1. Initial Setup
+    let user_keys = new_mnemonic(&SecretString("".to_string())).await?;
+
+    let blockchain = get_blockchain().await;
+    let secp = Secp256k1::new();
+    let db = MemoryDatabase::new();
+    let descriptor = user_keys
+        .private
+        .btc_descriptor_xprv
+        .into_wallet_descriptor(&secp, Network::Regtest)?;
+    let user_wallet_data = bdk::Wallet::new(descriptor, None, Network::Regtest, db)?;
+
+    let user_address = user_wallet_data.get_address(AddressIndex::New)?;
+    send_some_coins(&user_address.address.to_string(), "1").await;
+
+    user_wallet_data
+        .sync(&blockchain, SyncOptions::default())
+        .await?;
+    let mut builder = user_wallet_data.build_tx();
+
+    let address = user_wallet_data.get_address(AddressIndex::New)?;
+    builder.add_recipient(address.address.script_pubkey(), 100000);
+
+    builder.ordering(TxOrdering::Bip69Lexicographic);
+    builder.fee_rate(bdk::FeeRate::from_sat_per_vb(1.0));
+    builder.enable_rbf();
+
+    let (mut psbt, _) = builder.finish()?;
+
+    let _ = user_wallet_data.sign(&mut psbt, SignOptions::default())?;
+    // println!("{:#?}", signed);
+
+    let tx = psbt.extract_tx();
+
+    blockchain.broadcast(&tx).await?;
+
+    user_wallet_data
+        .sync(&blockchain, SyncOptions::default())
+        .await?;
+
+    let txs = user_wallet_data.list_transactions(false)?;
+    // println!("{:#?}", txs);
+
+    assert_eq!(2, txs.len());
+
+    let tx_1_utxos: Vec<String> = tx
+        .input
+        .clone()
+        .into_iter()
+        .map(|u| u.previous_output.to_string())
+        .collect();
+
+    let (mut psbt, ..) = {
+        let mut builder = user_wallet_data.build_fee_bump(tx.txid())?;
+        builder.fee_rate(bdk::FeeRate::from_sat_per_vb(5.0));
+        builder.finish()?
+    };
+
+    let _ = user_wallet_data.sign(&mut psbt, SignOptions::default())?;
+    let tx = psbt.extract_tx();
+    let blockchain = get_blockchain().await;
+    blockchain.broadcast(&tx).await?;
+
+    user_wallet_data
+        .sync(&blockchain, SyncOptions::default())
+        .await?;
+
+    let txs = user_wallet_data.list_transactions(false)?;
+    // println!("{:#?}", txs);
+
+    assert_eq!(2, txs.len());
+
+    let tx_2_utxos: Vec<String> = tx
+        .input
+        .into_iter()
+        .map(|u| u.previous_output.to_string())
+        .collect();
+
+    // println!("{:#?}", tx_1_utxos);
+    // println!("{:#?}", tx_2_utxos);
+    assert_eq!(tx_1_utxos, tx_2_utxos);
+
+    Ok(())
+}

--- a/tests/rgb/integration/udas.rs
+++ b/tests/rgb/integration/udas.rs
@@ -5,12 +5,12 @@ use crate::rgb::integration::utils::{
 };
 use bitmask_core::{
     bitcoin::{save_mnemonic, sign_and_publish_psbt_file},
-    rgb::accept_transfer,
+    rgb::{accept_transfer, structs::ContractAmount},
     structs::{AcceptRequest, SecretString, SignPsbtRequest},
 };
 
 #[tokio::test]
-async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
+async fn accept_uda_transfer() -> anyhow::Result<()> {
     let issuer_keys = &save_mnemonic(
         &SecretString(ISSUER_MNEMONIC.to_string()),
         &SecretString("".to_string()),
@@ -25,7 +25,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
     let issuer_resp = issuer_issue_contract_v2(
         1,
         "RGB21",
-        1,
+        ContractAmount::new(1, 0).to_value(),
         false,
         true,
         meta,
@@ -38,7 +38,7 @@ async fn allow_beneficiary_accept_transfer() -> anyhow::Result<()> {
     let owner_resp = create_new_invoice(
         &issuer_resp.contract_id,
         &issuer_resp.iface,
-        1,
+        1.0,
         owner_keys,
         None,
         Some(issuer_resp.clone().contract.legacy),

--- a/tests/rgb/web/swaps.rs
+++ b/tests/rgb/web/swaps.rs
@@ -176,7 +176,7 @@ async fn create_transfer_swap_flow() {
     assert!(owner_next_utxo.utxo.is_some());
 
     info!("Create Contract (Issuer)");
-    let supply = 5000_00;
+    let supply = 500_000;
     let precision = 2;
     let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
     let issue_seal = format!("tapret1st:{issue_utxo}");

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -8,6 +8,7 @@ use std::{assert_eq, str::FromStr, vec};
 use crate::rgb::web::utils::{new_block, send_coins};
 use bdk::blockchain::EsploraBlockchain;
 use bitcoin::{consensus, Transaction};
+use bitmask_core::rgb::structs::ContractAmount;
 use bitmask_core::web::constants::sleep;
 use bitmask_core::{
     debug, info,
@@ -46,12 +47,12 @@ const ENCRYPTION_PASSWORD: &str = "hunter2";
 const SEED_PASSWORD: &str = "";
 
 pub struct TransferRounds {
-    pub send_amount: u64,
+    pub send_amount: f64,
     pub is_issuer_sender: bool,
 }
 
 impl TransferRounds {
-    pub fn with(send_amount: u64, is_issuer_sender: bool) -> Self {
+    pub fn with(send_amount: f64, is_issuer_sender: bool) -> Self {
         TransferRounds {
             send_amount,
             is_issuer_sender,
@@ -63,38 +64,6 @@ impl TransferRounds {
 #[allow(unused_assignments)]
 async fn create_transfer_with_fee_value() {
     set_panic_hook();
-    // let issuer_mnemonic =
-    //     "try engine hurt mushroom adapt club boring diagram barely rail cable vicious tower boss hurt";
-    // let owner_mnemonic =
-    //     "rally ready surround evil grace autumn merry lunch husband infant forum wet possible thought drink";
-    // let hash = hash_password(ENCRYPTION_PASSWORD.to_owned());
-
-    // info!("Import wallet");
-    // let issuer_mnemonic = resolve(encrypt_wallet(
-    //     issuer_mnemonic.to_owned(),
-    //     hash.clone(),
-    //     SEED_PASSWORD.to_owned(),
-    // ))
-    // .await;
-    // let issuer_mnemonic: SecretString = json_parse(&issuer_mnemonic);
-
-    // let owner_mnemonic = resolve(encrypt_wallet(
-    //     owner_mnemonic.to_owned(),
-    //     hash.clone(),
-    //     SEED_PASSWORD.to_owned(),
-    // ))
-    // .await;
-    // let owner_mnemonic: SecretString = json_parse(&owner_mnemonic);
-
-    // info!("Get Issuer Vault");
-    // let issuer_vault: JsValue =
-    //     resolve(decrypt_wallet(hash.clone(), issuer_mnemonic.to_string())).await;
-    // let issuer_vault: DecryptedWalletData = json_parse(&issuer_vault);
-
-    // info!("Get Owner Vault");
-    // let owner_vault: JsValue = resolve(decrypt_wallet(hash, owner_mnemonic.to_string())).await;
-    // let owner_vault: DecryptedWalletData = json_parse(&owner_vault);
-
     let issuer_vault = resolve(new_mnemonic("".to_string())).await;
     let issuer_vault: DecryptedWalletData = json_parse(&issuer_vault);
     let owner_vault = resolve(new_mnemonic("".to_string())).await;
@@ -182,14 +151,15 @@ async fn create_transfer_with_fee_value() {
     assert!(owner_next_utxo.utxo.is_some());
 
     info!("Create Contract (Issuer)");
-    let supply = 100_000;
+    let supply = 1000_00;
+    let precision = 2;
     let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
     let issue_seal = format!("tapret1st:{issue_utxo}");
     let issue_req = IssueRequest {
         ticker: "DIBA".to_string(),
         name: "DIBA".to_string(),
         description: "DIBA".to_string(),
-        precision: 2,
+        precision,
         supply,
         seal: issue_seal.to_owned(),
         iface: iface.to_string(),
@@ -200,20 +170,22 @@ async fn create_transfer_with_fee_value() {
     let issue_resp: JsValue = resolve(issue_contract(issuer_sk.to_string(), issue_req)).await;
     let issuer_resp: IssueResponse = json_parse(&issue_resp);
 
-    let mut total_issuer = supply;
-    let mut total_owner = 0;
+    info!("Import Contract (Owner)");
+    let contract_import = ImportRequest {
+        import: AssetType::RGB20,
+        data: issuer_resp.contract.strict,
+    };
+
+    let req = serde_wasm_bindgen::to_value(&contract_import).expect("oh no!");
+    let resp = resolve(import_contract(owner_sk.clone(), req)).await;
+    let resp: ContractResponse = json_parse(&resp);
+
+    let mut total_issuer =
+        f64::from_str(&ContractAmount::with(supply, precision).to_string()).unwrap();
+    let mut total_owner = 0.0;
     let rounds = vec![
-        TransferRounds::with(20, true),
-        TransferRounds::with(20, false),
-        // TransferRounds::with(3_000, true),
-        // TransferRounds::with(5_000, true),
-        // TransferRounds::with(20, true),
-        // TransferRounds::with(8_000, false),
-        // TransferRounds::with(9_000, true),
-        // TransferRounds::with(9_000, false),
-        // TransferRounds::with(9_000, true),
-        // TransferRounds::with(20, false),
-        // TransferRounds::with(50_000, true),
+        TransferRounds::with(20.00, true),
+        TransferRounds::with(20.00, false),
     ];
 
     let mut sender = String::new();
@@ -268,10 +240,11 @@ async fn create_transfer_with_fee_value() {
         let params = HashMap::new();
         let receiver_utxo = receiver_next_utxo.utxo.unwrap().outpoint.to_string();
         let receiver_seal = format!("tapret1st:{receiver_utxo}");
+        let invoice_amount = ContractAmount::from(round.send_amount.to_string(), precision);
         let invoice_req = InvoiceRequest {
             contract_id: issuer_resp.contract_id.to_string(),
             iface: issuer_resp.iface.to_string(),
-            amount: round.send_amount,
+            amount: invoice_amount.to_string(),
             seal: receiver_seal,
             params,
         };
@@ -371,7 +344,7 @@ async fn create_transfer_with_fee_value() {
             "Contract ({sender}): {} ({})\n {:#?}",
             contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
         ));
-        let sender_current_balance = contract_resp.balance;
+        let sender_current_balance = contract_resp.balance_normalised;
 
         info!(format!("Get Contract Balancer ({receiver})"));
         let contract_resp = resolve(get_contract(
@@ -384,7 +357,7 @@ async fn create_transfer_with_fee_value() {
             "Contract ({receiver}): {} ({})\n {:#?}",
             contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
         ));
-        let receiver_current_balance = contract_resp.balance;
+        let receiver_current_balance = contract_resp.balance_normalised;
 
         info!(format!("<<<< ROUND #{index} Finish >>>>"));
         assert_eq!(sender_current_balance, sender_balance);
@@ -484,13 +457,14 @@ async fn create_transfer_with_fee_rate() {
 
     info!("Create Contract (Issuer)");
     let supply = 100_000;
+    let precision = 2;
     let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
     let issue_seal = format!("tapret1st:{issue_utxo}");
     let issue_req = IssueRequest {
         ticker: "DIBA".to_string(),
         name: "DIBA".to_string(),
         description: "DIBA".to_string(),
-        precision: 2,
+        precision,
         supply,
         seal: issue_seal.to_owned(),
         iface: iface.to_string(),
@@ -501,9 +475,20 @@ async fn create_transfer_with_fee_rate() {
     let issue_resp: JsValue = resolve(issue_contract(issuer_sk.to_string(), issue_req)).await;
     let issuer_resp: IssueResponse = json_parse(&issue_resp);
 
-    let mut total_issuer = supply;
-    let mut total_owner = 0;
-    let rounds = vec![TransferRounds::with(20, true)];
+    info!("Import Contract (Owner)");
+    let contract_import = ImportRequest {
+        import: AssetType::RGB20,
+        data: issuer_resp.contract.strict,
+    };
+
+    let req = serde_wasm_bindgen::to_value(&contract_import).expect("oh no!");
+    let resp = resolve(import_contract(owner_sk.clone(), req)).await;
+    let resp: ContractResponse = json_parse(&resp);
+
+    let mut total_issuer =
+        f64::from_str(&ContractAmount::with(supply, precision).to_string()).unwrap();
+    let mut total_owner = 0.00;
+    let rounds = vec![TransferRounds::with(20.00, true)];
 
     let mut sender = String::new();
     let mut sender_sk = String::new();
@@ -555,12 +540,13 @@ async fn create_transfer_with_fee_rate() {
 
         info!(format!("Create Invoice ({receiver})"));
         let params = HashMap::new();
+        let invoice_amount = ContractAmount::from(round.send_amount.to_string(), precision);
         let receiver_utxo = receiver_next_utxo.utxo.unwrap().outpoint.to_string();
         let receiver_seal = format!("tapret1st:{receiver_utxo}");
         let invoice_req = InvoiceRequest {
             contract_id: issuer_resp.contract_id.to_string(),
             iface: issuer_resp.iface.to_string(),
-            amount: round.send_amount,
+            amount: invoice_amount.to_string(),
             seal: receiver_seal,
             params,
         };
@@ -660,7 +646,7 @@ async fn create_transfer_with_fee_rate() {
             "Contract ({sender}): {} ({})\n {:#?}",
             contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
         ));
-        let sender_current_balance = contract_resp.balance;
+        let sender_current_balance = contract_resp.balance_normalised;
 
         info!(format!("Get Contract Balancer ({receiver})"));
         let contract_resp = resolve(get_contract(
@@ -673,7 +659,7 @@ async fn create_transfer_with_fee_rate() {
             "Contract ({receiver}): {} ({})\n {:#?}",
             contract_resp.contract_id, contract_resp.balance, contract_resp.allocations
         ));
-        let receiver_current_balance = contract_resp.balance;
+        let receiver_current_balance = contract_resp.balance_normalised;
 
         info!(format!("<<<< ROUND #{index} Finish >>>>"));
         assert_eq!(sender_current_balance, sender_balance);

--- a/tests/rgb/web/transfers.rs
+++ b/tests/rgb/web/transfers.rs
@@ -151,7 +151,7 @@ async fn create_transfer_with_fee_value() {
     assert!(owner_next_utxo.utxo.is_some());
 
     info!("Create Contract (Issuer)");
-    let supply = 1000_00;
+    let supply = 100_000;
     let precision = 2;
     let issue_utxo = issuer_next_utxo.utxo.unwrap().outpoint.to_string();
     let issue_seal = format!("tapret1st:{issue_utxo}");


### PR DESCRIPTION
### **Description**

This PR add support to fractions in issuer, create invoice and transfers (include swaps) operations.

#### **Changes (!!Important!!)**

I was need change some **pre-reqs** of the issue #363 for feature work correctly.  In my tests, I identify some problems with we send only whole and fraction. See bellow:

1. **Conversions:** Each language (Rust, TS and JS) have different ways to convert and handle numbers and this leaves room for countless errors. To avoid wrong conversions, I decided change the type of `contract amount` from number to string and handle in BMC. The BME send the follow representations of the fractional number: `2.`, `2.0`, `2.0`, `2.0000001`, `2.5`, etc..
2. **Precisions:** Another problem is contract precisions. To avoid user send wrong  values in invoice, I change the invoice amount to string too. Also, now the **receiver** needs already imported contract, because we checked if user send a correct precision number. Also, I create the method called **get_simple_contract** in web.rs to return the contract precision data.

Closes #363 