### PR TITLE
Add csv and json wallet metrics endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "tokio",
  "toml 0.7.8",
  "tower-http",
+ "walkdir",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -2938,6 +2939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +3998,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ strict_types = "1.6.3"
 thiserror = "1.0"
 tokio = { version = "1.33.0", features = ["macros", "sync"] }
 zeroize = "1.6.0"
+walkdir = "2.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bdk = { version = "0.28.2", features = [

--- a/src/carbonado.rs
+++ b/src/carbonado.rs
@@ -4,6 +4,7 @@ use bitcoin_30::secp256k1::{PublicKey, SecretKey};
 use crate::{carbonado::error::CarbonadoError, constants::NETWORK, info, structs::FileMetadata};
 
 pub mod error;
+pub mod metrics;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{handle_file, retrieve, retrieve_metadata, server_retrieve, server_store, store};

--- a/src/carbonado/metrics.rs
+++ b/src/carbonado/metrics.rs
@@ -1,0 +1,204 @@
+use std::{collections::BTreeMap, path::Path, time::SystemTime};
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct MetricsResponse {
+    bytes: u64,
+    bytes_by_day: BTreeMap<String, u64>,
+    bitcoin_wallets_by_day: BTreeMap<String, usize>,
+    wallets_by_network: BTreeMap<String, usize>,
+}
+
+pub fn metrics(dir: &Path) -> Result<MetricsResponse> {
+    let mut response = MetricsResponse::default();
+
+    response.wallets_by_network.insert("bitcoin".to_string(), 0);
+    response.wallets_by_network.insert("testnet".to_string(), 0);
+    response.wallets_by_network.insert("signet".to_string(), 0);
+    response.wallets_by_network.insert("regtest".to_string(), 0);
+    response.wallets_by_network.insert("total".to_string(), 0);
+
+    let mut total_wallets = 0;
+    let mut day_prior = None;
+
+    for entry in WalkDir::new(dir) {
+        let entry = entry?;
+        let filename = entry.file_name().to_string_lossy().to_string();
+        let metadata = entry.metadata()?;
+        let day = metadata.created()?;
+        let day = round_system_time_to_day(day);
+
+        if metadata.is_file() {
+            response.bytes += metadata.len();
+
+            let bytes_total_day_prior = if let Some(dp) = &day_prior {
+                response.bytes_by_day.get(dp).unwrap_or(&0).to_owned()
+            } else {
+                0
+            };
+
+            let bitcoin_wallets_total_day_prior = if let Some(dp) = day_prior {
+                response
+                    .bitcoin_wallets_by_day
+                    .get(&dp)
+                    .unwrap_or(&0)
+                    .to_owned()
+            } else {
+                0
+            };
+
+            *response
+                .bytes_by_day
+                .entry(day.clone())
+                .or_insert(bytes_total_day_prior) += metadata.len();
+
+            if filename
+                == "bitcoin-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+            {
+                *response
+                    .wallets_by_network
+                    .get_mut("bitcoin")
+                    .unwrap_or(&mut 0) += 1;
+                *response
+                    .bitcoin_wallets_by_day
+                    .entry(day.clone())
+                    .or_insert(bitcoin_wallets_total_day_prior) += 1;
+            }
+
+            if filename
+                == "testnet-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+            {
+                *response
+                    .wallets_by_network
+                    .get_mut("testnet")
+                    .unwrap_or(&mut 0) += 1;
+            }
+
+            if filename
+                == "signet-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+            {
+                *response
+                    .wallets_by_network
+                    .get_mut("signet")
+                    .unwrap_or(&mut 0) += 1;
+            }
+
+            if filename
+                == "regtest-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+            {
+                *response
+                    .wallets_by_network
+                    .get_mut("regtest")
+                    .unwrap_or(&mut 0) += 1;
+            }
+
+            if filename == "bitcoin-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+                || filename == "testnet-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+                || filename == "signet-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+                || filename == "regtest-6075e9716c984b37840f76ad2b50b3d1b98ed286884e5ceba5bcc8e6b74988d3.c15"
+            {
+                total_wallets += 1;
+            }
+        }
+
+        day_prior = Some(day);
+    }
+
+    *response
+        .wallets_by_network
+        .get_mut("total")
+        .unwrap_or(&mut 0) = total_wallets;
+
+    Ok(response)
+}
+
+pub fn metrics_csv(metrics: MetricsResponse) -> String {
+    let lines = vec![vec![
+        "Wallet",
+        "Wallet Count",
+        "Bytes Total",
+        "Day",
+        "Bitcoin Wallets by Day",
+        "Bytes by Day",
+    ]];
+
+    for (day, bitcoin_wallets) in metrics.bitcoin_wallets_by_day {
+        let mut line = vec![];
+
+        if lines.len() == 1 {
+            line.push("Bitcoin".to_string());
+            line.push(
+                metrics
+                    .wallets_by_network
+                    .get("bitcoin")
+                    .unwrap()
+                    .to_string(),
+            );
+            line.push(metrics.bytes.to_string());
+        }
+
+        if lines.len() == 2 {
+            line.push("Tesnet".to_string());
+            line.push(
+                metrics
+                    .wallets_by_network
+                    .get("testnet")
+                    .unwrap()
+                    .to_string(),
+            );
+            line.push("".to_owned());
+        }
+
+        if lines.len() == 3 {
+            line.push("signet".to_string());
+            line.push(
+                metrics
+                    .wallets_by_network
+                    .get("signet")
+                    .unwrap()
+                    .to_string(),
+            );
+            line.push("".to_owned());
+        }
+
+        if lines.len() == 4 {
+            line.push("regtest".to_string());
+            line.push(
+                metrics
+                    .wallets_by_network
+                    .get("regtest")
+                    .unwrap()
+                    .to_string(),
+            );
+            line.push("".to_owned());
+        }
+
+        if lines.len() > 4 {
+            line.push("".to_owned());
+            line.push("".to_owned());
+            line.push("".to_owned());
+        }
+
+        line.push(day.clone());
+        line.push(bitcoin_wallets.to_string());
+        line.push(metrics.bytes_by_day.get(&day).unwrap().to_string())
+    }
+
+    let lines: Vec<String> = lines.iter().map(|line| line.join(",")).collect();
+    lines.join("\n")
+}
+
+fn round_system_time_to_day(system_time: SystemTime) -> String {
+    // Convert SystemTime to a Chrono DateTime
+    let datetime: DateTime<Utc> = system_time.into();
+
+    // Round down to the nearest day (00:00:00)
+    let rounded = datetime.date_naive().and_hms_opt(0, 0, 0).unwrap();
+
+    // Format the date as a string in "YYYY-MM-DD" format
+    rounded.format("%Y-%m-%d").to_string()
+}


### PR DESCRIPTION
Add a Carbonado and wallets metrics endpoint.

Example output:

```json
{"bytes":1021176592,"bytes_by_day":{"2023-11-12":1021176592},"bitcoin_wallets_by_day":{"2023-11-12":22474},"wallets_by_network":{"bitcoin":22474,"regtest":21167,"signet":22855,"testnet":17803,"total":84299}}
```