### PR TITLE
Fix #424 by iterating original_input on match

### DIFF
--- a/src/bitcoin/payment.rs
+++ b/src/bitcoin/payment.rs
@@ -175,8 +175,8 @@ fn add_back_original_input(original_psbt: &Psbt, payjoin_psbt: Psbt) -> Psbt {
             if proposed_txin.previous_output == original_txin.previous_output {
                 proposed_psbtin.witness_utxo = original_psbtin.witness_utxo.clone();
                 proposed_psbtin.non_witness_utxo = original_psbtin.non_witness_utxo.clone();
+                original_inputs.next();
             }
-            original_inputs.next();
         }
     }
     payjoin_psbt


### PR DESCRIPTION
The payjoin psbt construction code reintroduces original psbt inputs that the receiver may have lost. It does this by iterating through each proposed input and original input.

This fix only iterates to the next original_input once a proposed input that matches is found, otherwise inputs could be skipped and signing could fail. The outer loop already iterates through proposed inputs. Inputs in the proposal are in the same order as the original as per spec, and just insert receiver inputs so this iteration will always find matches.