### PR TITLE
Recompute keys from mnemonic whenever decrypting an existing wallet.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,8 @@
   "files.autoSave": "onFocusChange",
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
-  "rust-analyzer.cargo.features": "all", // Enable only for desktop
   "rust-analyzer.check.allTargets": true,
+  "rust-analyzer.cargo.features": "all", // Enable only for desktop
   // "rust-analyzer.cargo.target": "wasm32-unknown-unknown", // Enable only for web
   // "rust-analyzer.check.noDefaultFeatures": true, // Enable for web
   // "rust-analyzer.runnables.extraArgs": ["--release"], // Enable for web

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -135,7 +135,7 @@ pub fn hash_password(password: &SecretString) -> SecretString {
     hash
 }
 
-pub fn decrypt_wallet(
+pub async fn decrypt_wallet(
     hash: &SecretString,
     encrypted_descriptors: &SecretString,
 ) -> Result<DecryptedWalletData, BitcoinError> {
@@ -163,6 +163,13 @@ pub fn decrypt_wallet(
         DecryptedWalletData::decrypt_owned(&encrypted_message, &SharedKey::from_array(shared_key))?;
 
     shared_key.zeroize();
+
+    // Recompute keys from mnemonic
+    let decrypted_wallet_data = save_mnemonic(
+        &SecretString(decrypted_wallet_data.mnemonic.to_owned()),
+        &SecretString("".to_string()),
+    )
+    .await?;
 
     Ok(decrypted_wallet_data)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -144,7 +144,9 @@ pub mod bitcoin {
             match crate::bitcoin::decrypt_wallet(
                 &SecretString(hash),
                 &SecretString(encrypted_descriptors),
-            ) {
+            )
+            .await
+            {
                 Ok(result) => Ok(JsValue::from_string(
                     serde_json::to_string(&result).unwrap(),
                 )),

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -25,7 +25,8 @@ async fn migration_v4() -> Result<()> {
     let wallet = decrypt_wallet(
         &SecretString(ENCRYPTION_PASSWORD.to_owned()),
         &SecretString(ENCRYPTED_DESCRIPTOR_04.to_owned()),
-    );
+    )
+    .await;
 
     assert!(wallet.is_err(), "Importing an old descriptor should error");
 
@@ -44,7 +45,8 @@ async fn migration_v4() -> Result<()> {
     let wallet = decrypt_wallet(
         &SecretString(ENCRYPTION_PASSWORD.to_owned()),
         &upgraded_descriptor,
-    )?;
+    )
+    .await?;
 
     assert_eq!(
         wallet.public.xpub, "tpubD6NzVbkrYhZ4Xxrh54Ew5kjkagEfUhS3aCNqRJmUuNfnTXhK4LGXyUzZ5kxgn8f2txjnFtypnoYfRQ9Y8P2nhSNXffxVKutJgxNPxgmwpUR",
@@ -65,7 +67,8 @@ async fn migration_v5() -> Result<()> {
     let wallet = decrypt_wallet(
         &SecretString(ENCRYPTION_PASSWORD.to_owned()),
         &SecretString(ENCRYPTED_DESCRIPTOR_05.to_owned()),
-    );
+    )
+    .await;
 
     assert!(wallet.is_err(), "Importing an old descriptor should error");
 
@@ -84,7 +87,8 @@ async fn migration_v5() -> Result<()> {
     let wallet = decrypt_wallet(
         &SecretString(ENCRYPTION_PASSWORD.to_owned()),
         &upgraded_descriptor,
-    )?;
+    )
+    .await?;
 
     assert_eq!(
         wallet.public.xpub, "tpubD6NzVbkrYhZ4XJmEMNjxuARFrP5kME8ndqpk9M2QeqtuTv2kTrm87a93Td47bHRRCrSSVvVEu3trvwthVswtPNwK2Kyc9PpudxC1MZrPuNL",

--- a/tests/payjoin.rs
+++ b/tests/payjoin.rs
@@ -31,7 +31,7 @@ async fn payjoin() -> Result<()> {
     )
     .await?;
 
-    let vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
+    let vault = decrypt_wallet(&hash, &encrypted_descriptors).await?;
 
     let wallet = get_wallet_data(
         &SecretString(vault.private.btc_descriptor_xprv.clone()),

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -50,7 +50,7 @@ async fn create_wallet() -> Result<()> {
     info!("Create wallet");
     let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     let encrypted_descriptors = new_wallet(&hash, &SecretString(SEED_PASSWORD.to_owned())).await?;
-    let decrypted_wallet = decrypt_wallet(&hash, &encrypted_descriptors)?;
+    let decrypted_wallet = decrypt_wallet(&hash, &encrypted_descriptors).await?;
 
     let main_btc_wallet = get_wallet_data(
         &SecretString(decrypted_wallet.private.btc_descriptor_xprv.clone()),
@@ -81,14 +81,14 @@ async fn import_wallet() -> Result<()> {
     let main_mnemonic = SecretString(env::var("TEST_WALLET_SEED")?);
     let hash0 = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash0, &seed_password).await?;
-    let _main_vault = decrypt_wallet(&hash0, &encrypted_descriptors)?;
+    let _main_vault = decrypt_wallet(&hash0, &encrypted_descriptors).await?;
 
     info!("Try once more");
     let hash1 = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     assert_eq!(hash0.0, hash1.0, "hashes match");
 
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash1, &seed_password).await?;
-    let main_vault = decrypt_wallet(&hash1, &encrypted_descriptors)?;
+    let main_vault = decrypt_wallet(&hash1, &encrypted_descriptors).await?;
 
     let main_btc_wallet = get_wallet_data(
         &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
@@ -116,7 +116,7 @@ async fn get_wallet_balance() -> Result<()> {
     let seed_password = SecretString(SEED_PASSWORD.to_owned());
     let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash, &seed_password).await?;
-    let main_vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
+    let main_vault = decrypt_wallet(&hash, &encrypted_descriptors).await?;
 
     let btc_wallet = get_wallet_data(
         &SecretString(main_vault.private.btc_descriptor_xprv.clone()),
@@ -144,7 +144,7 @@ async fn wrong_network() -> Result<()> {
     let hash = hash_password(&SecretString(ENCRYPTION_PASSWORD.to_owned()));
     let encrypted_descriptors = encrypt_wallet(&main_mnemonic, &hash, &seed_password).await?;
 
-    let main_vault = decrypt_wallet(&hash, &encrypted_descriptors)?;
+    let main_vault = decrypt_wallet(&hash, &encrypted_descriptors).await?;
 
     let result = send_sats(
         &SecretString(main_vault.private.btc_descriptor_xprv.to_owned()),


### PR DESCRIPTION
I've done some experimenting, and I've noticed that I sometimes on certain wallets get a different xpub. This recomputes the keys whenever decrypting the wallet, and after some testing, I've found those keys to be correct.