### PR TITLE
Fix Bump Fee

### DIFF
--- a/lib/web/bitcoin.ts
+++ b/lib/web/bitcoin.ts
@@ -95,9 +95,9 @@ export const drainWallet = async (
 export const bumpFee = async (
   txid: string,
   feeRate: number,
+  broadcast: boolean,
   descriptor: string,
-  changeDescriptor: string,
-  broadcast: boolean
+  changeDescriptor?: string,
 ): Promise<TransactionData> =>
   JSON.parse(
     await BMC.bump_fee(txid, feeRate, descriptor, changeDescriptor, broadcast)

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -636,12 +636,12 @@ pub async fn bump_fee(
     txid: String,
     fee_rate: f32,
     descriptor: &SecretString,
-    change_descriptor: &SecretString,
+    change_descriptor: Option<&SecretString>,
     broadcast: bool,
 ) -> Result<TransactionData, BitcoinError> {
     let txid = Txid::from_str(&txid)?;
 
-    let wallet = get_wallet(descriptor, Some(change_descriptor)).await?;
+    let wallet = get_wallet(descriptor, change_descriptor).await?;
 
     if broadcast {
         sync_wallet(&wallet).await?;

--- a/src/web.rs
+++ b/src/web.rs
@@ -377,17 +377,18 @@ pub mod bitcoin {
         txid: String,
         fee_rate: f32,
         descriptor: String,
-        change_descriptor: String,
+        change_descriptor: Option<String>,
         broadcast: bool,
     ) -> Promise {
         set_panic_hook();
 
         future_to_promise(async move {
+            let change_descriptor = change_descriptor.map(SecretString);
             match crate::bitcoin::bump_fee(
                 txid,
                 fee_rate,
                 &SecretString(descriptor),
-                &SecretString(change_descriptor),
+                change_descriptor.as_ref(),
                 broadcast,
             )
             .await


### PR DESCRIPTION
**Description**

After investigating the error in  `create_bdk_rbf_transaction`, I noticed the strange behavior in the **BDK rbf** method. When we create a transaction builder from the `Wallet::build_fee_bump` method with **descriptor** and **change_descriptor**, the **BDK** gets all outputs recipients, including "final change output", and this avoids **BDK** apply replace by fee policy.

For example, 
Suppose you have 100.000 sats and create a new transaction, sending 10.000 sats to the address; the BDK generates the following transaction:

In   (1):   100.000
out (1):   10.000
out (2):   98.000

fee:        1.000

When we try to send a new transaction with **descriptor** and **change_descriptor**,  the BDK retrieves both outs instead of only the first out (10.000 sats). Then, BDK raises an inflation exception. 