### PR TITLE
fix: taproot derived xpub

### DIFF
--- a/src/bitcoin/keys.rs
+++ b/src/bitcoin/keys.rs
@@ -210,7 +210,7 @@ pub async fn get_mnemonic(
     };
 
     let public = PublicWalletData {
-        xpub: xpub.to_string(),
+        xpub: watcher_xpub.clone(),
         xpubkh,
         watcher_xpub,
         btc_descriptor_xpub,

--- a/tests/keys.rs
+++ b/tests/keys.rs
@@ -10,7 +10,7 @@ use bitmask_core::{
 
 #[tokio::test]
 pub async fn taproot() -> Result<()> {
-    init_logging("nostr_tests=debug");
+    init_logging("taproot=debug");
 
     const MNEMONIC: &str =
         "empty faculty salute fortune select asthma attract question violin movie smile erupt half step lion deposit render stumble double mobile fossil height usual topple";
@@ -34,6 +34,12 @@ pub async fn taproot() -> Result<()> {
         decrypted_wallet.public.btc_descriptor_xpub,
         "tr([496f1ccc/86'/0'/0']xpub6CBkARCPxmbRjaxzHxC38e9sKUVtMTRFqBYUFdXAHFBpeQzJz6mYSaQ1qSvCrNzYUNuvpD9FS6fmK9YowdCxaiCUSpjzNm5hvV2JxEodZ1q/0/*)",
         "correct taproot xpub descriptor is derived from mnemonic"
+    );
+
+    assert_eq!(
+        decrypted_wallet.public.xpub,
+        "xpub6CBkARCPxmbRjaxzHxC38e9sKUVtMTRFqBYUFdXAHFBpeQzJz6mYSaQ1qSvCrNzYUNuvpD9FS6fmK9YowdCxaiCUSpjzNm5hvV2JxEodZ1q",
+        "correct taproot xpub is derived from mnemonic"
     );
 
     assert_eq!(


### PR DESCRIPTION
The example seed phrase was providing the the main extended public key. i.e derivation path `m` This can be confirmed on [bip32.net](https://bip32.net/)

Here's the `m` derivation in the current version:

![image](https://github.com/diba-io/bitmask-core/assets/80722374/d8363fa0-f25b-4b8d-86c3-df47b409aba5)

![image](https://github.com/diba-io/bitmask-core/assets/80722374/46268a25-2838-4833-85ba-1e91908b2ba6)

We needed to provide an `xpub` that included the taproot descriptor. Since we already had the function `watcher_xpub`, that's all that needed to be switch out.

Now, if a user wants to copy the xpub for a watch only wallet; they will see

With the additional test, we can see that we now have the proper watch-only address.
